### PR TITLE
Message length increased

### DIFF
--- a/llvm/tools/llvm-snippy/lib/Generator/SimRunner.cpp
+++ b/llvm/tools/llvm-snippy/lib/Generator/SimRunner.cpp
@@ -45,7 +45,7 @@ ProgramCounterType SimRunner::run(StringRef Programm,
   checkStates(/* CheckMemory */ true);
 
   auto &PrimI = getPrimaryInterpreter();
-  PrimI.logMessage("#===Simulation Start===\n");
+  PrimI.logMessage("==============================Simulation Start==============================\n");
 
   while (!PrimI.endOfProg()) {
     if (std::any_of(CoInterp.begin(), CoInterp.end(),


### PR DESCRIPTION
Message about starting the simulation "#===Simulation Start==="  made longer.
This will allow for a clearer separation of the snippy output at generation time from the model output at run time.