### PR TITLE
[snippy] Place insertion hint before first BB terminator.

### DIFF
--- a/llvm/test/tools/llvm-snippy/histogram-insert-hints-with-branches.yaml
+++ b/llvm/test/tools/llvm-snippy/histogram-insert-hints-with-branches.yaml
@@ -1,0 +1,19 @@
+# RUN: llvm-snippy %s -march=riscv64-linux-gnu -generate-insertion-point-hints \
+# RUN: -verify-mi -num-instrs=10 -model-plugin=None
+
+sections:
+    - no:        1
+      VMA:       0x80000000
+      SIZE:      0x400000
+      LMA:       0x80000000
+      ACCESS:    rx
+    - no:        2
+      VMA:       0x80600000
+      SIZE:      0x400000
+      LMA:       0x80600000
+      ACCESS:    rw
+
+histogram:
+    - [ADD, 9.0]
+    - [BEQ, 1.0]
+

--- a/llvm/test/tools/llvm-snippy/histogram-insert-hints-with-branches.yaml
+++ b/llvm/test/tools/llvm-snippy/histogram-insert-hints-with-branches.yaml
@@ -1,5 +1,5 @@
 # RUN: llvm-snippy %s -march=riscv64-linux-gnu -generate-insertion-point-hints \
-# RUN: -verify-mi -num-instrs=10 -model-plugin=None
+# RUN: -verify-mi -num-instrs=1000 -model-plugin=None
 
 sections:
     - no:        1

--- a/llvm/tools/llvm-snippy/lib/FlowGenerator.cpp
+++ b/llvm/tools/llvm-snippy/lib/FlowGenerator.cpp
@@ -633,7 +633,7 @@ void InstructionGenerator::generateInstruction(
          "All branch instructions expected to be generated separately");
 
   if (GenerateInsertionPointHints)
-    generateInsertionPointHint(MBB, MBB.end());
+    generateInsertionPointHint(MBB, MBB.getFirstTerminator());
 
   if (SnippyTgt.requiresCustomGeneration(InstrDesc)) {
     SnippyTgt.generateCustomInst(InstrDesc, MBB, *SGCtx, Ins);
@@ -1547,7 +1547,7 @@ void InstructionGenerator::generateBurst(
   const auto &InstrInfo = State.getInstrInfo();
 
   if (GenerateInsertionPointHints)
-    generateInsertionPointHint(MBB, MBB.end());
+    generateInsertionPointHint(MBB, MBB.getFirstTerminator());
 
   auto Opcodes = generateOpcodesForFixedSizedGroup(BurstGroupRequest, *SGCtx);
 


### PR DESCRIPTION
[snippy] Place insertion hint before first BB terminator.

Old placement at the end of BB causes an error, as nop is placed after PseudoBR.\
Fixed by specifying place for nop to be generated at before BB terminator.