### PR TITLE
[snippy] Automatically reserve gp and tp if external callees are present

### DIFF
--- a/llvm/test/tools/llvm-snippy/auto-reserve-regs-for-call.yaml
+++ b/llvm/test/tools/llvm-snippy/auto-reserve-regs-for-call.yaml
@@ -1,0 +1,47 @@
+# RUN: llvm-snippy %s --model-plugin None | \
+# RUN: FileCheck %s --ignore-case
+
+options:
+  march: riscv64-unknown-elf
+  mcpu: generic-rv64
+  mattr: "+f,+d"
+  num-instrs: 1000
+  init-regs-in-elf: on
+  dump-mf: on
+
+sections:
+  - no:        0
+    VMA:       0x200000
+    SIZE:      0x10000
+    LMA:       0x200000
+    ACCESS:    r
+  - no:        1
+    VMA:       0x210000
+    SIZE:      0x100000
+    LMA:       0x210000
+    ACCESS:    rx
+  - no:        2
+    VMA:       0x400000
+    SIZE:      0x100000
+    LMA:       0x400000
+    ACCESS:    rw
+
+call-graph:
+  entry-point: SnippyFunction
+  function-list:
+    - name: SnippyFunction
+      callees:
+        - myfunc
+    - name: myfunc
+      external: true
+
+histogram:
+     - [FADD_D, 3.0]
+     - [FDIV_D, 3.0]
+     - [FMUL_D, 3.0]
+     - [FSUB_D, 3.0]
+     - [JAL, 1.0]
+     - [ADDIW, 1.0]
+
+# CHECK-NOT: {{x3[[:space:],]}}
+# CHECK-NOT: x4

--- a/llvm/tools/llvm-snippy/include/snippy/Target/Target.h
+++ b/llvm/tools/llvm-snippy/include/snippy/Target/Target.h
@@ -456,6 +456,8 @@ public:
   virtual std::function<bool(unsigned)>
   getDefaultPolicyFilter(const MachineBasicBlock &MBB,
                          const GeneratorContext &GC) const = 0;
+  // Registers that should be valid while calling an external function
+  virtual std::vector<MCRegister> getGlobalStateRegs() const = 0;
 
 private:
   virtual bool matchesArch(Triple::ArchType Arch) const = 0;

--- a/llvm/tools/llvm-snippy/lib/Target/RISCV/Target.cpp
+++ b/llvm/tools/llvm-snippy/lib/Target/RISCV/Target.cpp
@@ -1678,6 +1678,12 @@ public:
             RISCV::X27};
   }
 
+  // X3 is a thread pointer and X4 is a global pointer. We must preserve them so
+  // they have valid values when we call external functions.
+  std::vector<MCRegister> getGlobalStateRegs() const override {
+    return {RISCV::X3, RISCV::X4};
+  }
+
   MCRegister getStackPointer() const override { return RISCV::X2; }
 
   void generateSpill(MachineBasicBlock &MBB, MachineBasicBlock::iterator Ins,

--- a/llvm/tools/llvm-snippy/lib/Target/X86/Target.cpp
+++ b/llvm/tools/llvm-snippy/lib/Target/X86/Target.cpp
@@ -436,6 +436,9 @@ public:
     reportUnimplementedError();
   }
 
+  std::vector<MCRegister> getGlobalStateRegs() const override {
+    reportUnimplementedError();
+  }
 }; // namespace
 
 bool SnippyX86Target::matchesArch(Triple::ArchType Arch) const {


### PR DESCRIPTION
tp and gp registers should be valid if we call external functions. We
can reserve these registers for the whole snippet to avoid their
corruption.