### PR TITLE
[snippy] Remove 'model' from riscv-rvv requirement

### DIFF
--- a/llvm/test/tools/llvm-snippy/lit.local.cfg
+++ b/llvm/test/tools/llvm-snippy/lit.local.cfg
@@ -8,6 +8,9 @@ from lit.llvm.subst import FindTool
 SnippyModel = 'None'
 Seed = lit_config.params.get('snippy-seed', '1')
 
+if SnippyModel == 'None':
+  config.available_features.add('riscv-rvv')
+
 
 
 SnippyTool = ToolSubst(


### PR DESCRIPTION
Add a way to filter RVV tests

This commit adds support for "REQUIRES: riscv-rvv" to provide more precise
filtering of tests containing RVV instructions.