### PR TITLE
[snippy] FP register aliases must be taken into account

### DIFF
--- a/llvm/test/tools/llvm-snippy/reserved-regs/FP-reserved-aliases-2.yaml
+++ b/llvm/test/tools/llvm-snippy/reserved-regs/FP-reserved-aliases-2.yaml
@@ -1,0 +1,92 @@
+# COM: This test checks that if registers Fx_F are reserved, 
+# COM: which are sub-registers of Fx_D, then both of them 
+# COM: are not found in the machine function dump.
+
+# RUN: llvm-snippy %s -model-plugin=None \
+# RUN:  |& FileCheck %s
+
+options:
+  march: riscv64-linux-gnu
+  mcpu: generic-rv64
+  mattr: +f,+d
+  dump-mf: on
+  num-instrs: 10000
+  reserved-regs-list: [F0_F,F1_F,F2_F,F3_F,F4_F,F5_F,F6_F,F7_F,F8_F,F9_F,F10_F,F11_F,F12_F,F13_F,F14_F,F15_F,F16_F,F17_F,F18_F,F19_F,F20_F,F21_F,F22_F,F23_F,F24_F,F25_F,F26_F,F27_F,F28_F,F29_F,F30_F]
+
+sections:
+    - no:        1
+      VMA:       0x80000000
+      SIZE:      0x400000
+      LMA:       0x80000000
+      ACCESS:    rx
+    - no:        2
+      VMA:       0x80600000
+      SIZE:      0x400000
+      LMA:       0x80600000
+      ACCESS:    rw
+
+histogram:
+    - [FADD_D, 1.0]
+
+# CHECK-NOT: f1_f 
+# CHECK-NOT: f2_f 
+# CHECK-NOT: f3_f 
+# CHECK-NOT: f4_f 
+# CHECK-NOT: f5_f 
+# CHECK-NOT: f6_f 
+# CHECK-NOT: f7_f 
+# CHECK-NOT: f8_f 
+# CHECK-NOT: f9_f 
+# CHECK-NOT: f10_f 
+# CHECK-NOT: f11_f 
+# CHECK-NOT: f12_f 
+# CHECK-NOT: f13_f 
+# CHECK-NOT: f14_f 
+# CHECK-NOT: f15_f 
+# CHECK-NOT: f16_f 
+# CHECK-NOT: f17_f 
+# CHECK-NOT: f18_f 
+# CHECK-NOT: f19_f 
+# CHECK-NOT: f20_f 
+# CHECK-NOT: f21_f 
+# CHECK-NOT: f22_f 
+# CHECK-NOT: f23_f 
+# CHECK-NOT: f24_f 
+# CHECK-NOT: f25_f 
+# CHECK-NOT: f26_f 
+# CHECK-NOT: f27_f 
+# CHECK-NOT: f28_f 
+# CHECK-NOT: f29_f 
+# CHECK-NOT: f30_f 
+
+# CHECK-NOT: f1_d 
+# CHECK-NOT: f2_d 
+# CHECK-NOT: f3_d 
+# CHECK-NOT: f4_d 
+# CHECK-NOT: f5_d 
+# CHECK-NOT: f6_d 
+# CHECK-NOT: f7_d 
+# CHECK-NOT: f8_d 
+# CHECK-NOT: f9_d 
+# CHECK-NOT: f10_d 
+# CHECK-NOT: f11_d 
+# CHECK-NOT: f12_d 
+# CHECK-NOT: f13_d 
+# CHECK-NOT: f14_d 
+# CHECK-NOT: f15_d 
+# CHECK-NOT: f16_d 
+# CHECK-NOT: f17_d 
+# CHECK-NOT: f18_d 
+# CHECK-NOT: f19_d 
+# CHECK-NOT: f20_d 
+# CHECK-NOT: f21_d 
+# CHECK-NOT: f22_d 
+# CHECK-NOT: f23_d 
+# CHECK-NOT: f24_d 
+# CHECK-NOT: f25_d 
+# CHECK-NOT: f26_d 
+# CHECK-NOT: f27_d 
+# CHECK-NOT: f28_d 
+# CHECK-NOT: f29_d 
+# CHECK-NOT: f30_d 
+

--- a/llvm/test/tools/llvm-snippy/reserved-regs/FP-reserved-aliases-3.yaml
+++ b/llvm/test/tools/llvm-snippy/reserved-regs/FP-reserved-aliases-3.yaml
@@ -1,0 +1,148 @@
+# COM: This test checks that if registers Fx_D and Fy_F are reserved, 
+# COM: then Fx_D, Fx_F, Fy_D and Fy_F
+# COM: are not found in the machine function dump.
+
+# RUN: llvm-snippy %s -model-plugin=None \
+# RUN:  |& FileCheck %s
+
+options:
+  march: riscv64-linux-gnu
+  mcpu: generic-rv64
+  mattr: +f,+d
+  dump-mf: on
+  num-instrs: 10000
+  reserved-regs-list: [F0_D,F1_D,F2_D,F3_D,F4_D,F5_D,F6_D,F7_D,F8_D,F9_D,F10_D,F11_D,F12_D,F15_F,F16_F,F17_F,F18_F,F19_F,F20_F,F21_F,F22_F,F25_F,F26_F,F27_F,F28_F,F29_F,F30_F,F31_F]
+
+sections:
+    - no:        1
+      VMA:       0x80000000
+      SIZE:      0x400000
+      LMA:       0x80000000
+      ACCESS:    rx
+    - no:        2
+      VMA:       0x80600000
+      SIZE:      0x400000
+      LMA:       0x80600000
+      ACCESS:    rw
+
+histogram:
+    - [FADD_S, 1.0]
+    - [FMSUB_S, 1.0]
+    - [FNMSUB_S, 1.0]
+    - [FNMADD_S, 1.0]
+    - [FADD_S, 1.0]
+    - [FSUB_S, 1.0]
+    - [FMUL_S, 1.0]
+    - [FDIV_S, 1.0]
+    - [FSQRT_S, 1.0]
+    - [FSGNJ_S, 1.0]
+    - [FSGNJN_S, 1.0]
+    - [FSGNJX_S, 1.0]
+    - [FMIN_S, 1.0]
+    - [FMAX_S, 1.0]
+    - [FCVT_W_S, 1.0]
+    - [FCVT_WU_S, 1.0]
+    - [FMV_X_W, 1.0]
+    - [FEQ_S, 1.0]
+    - [FLT_S, 1.0]
+    - [FLE_S, 1.0]
+    - [FCLASS_S, 1.0]
+    - [FCVT_S_W, 1.0]
+    - [FCVT_S_WU, 1.0]
+    - [FMV_W_X, 1.0]
+    - [FCVT_L_S, 1.0]
+    - [FCVT_LU_S, 1.0]
+    - [FCVT_S_L, 1.0]
+    - [FCVT_S_LU, 1.0]
+    - [FLW, 1.0]
+    - [FSW, 1.0]
+
+    - [FMADD_D, 1.0]
+    - [FMSUB_D, 1.0]
+    - [FNMSUB_D, 1.0]
+    - [FNMADD_D, 1.0]
+    - [FADD_D, 1.0]
+    - [FSUB_D, 1.0]
+    - [FMUL_D, 1.0]
+    - [FDIV_D, 1.0]
+    - [FSQRT_D, 1.0]
+    - [FSGNJ_D, 1.0]
+    - [FSGNJN_D, 1.0]
+    - [FSGNJX_D, 1.0]
+    - [FMIN_D, 1.0]
+    - [FMAX_D, 1.0]
+    - [FCVT_W_D, 1.0]
+    - [FCVT_WU_D, 1.0]
+    - [FCVT_D_W, 1.0]
+    - [FCVT_D_WU, 1.0]
+    - [FMV_X_D, 1.0]
+    - [FEQ_D, 1.0]
+    - [FLT_D, 1.0]
+    - [FLE_D, 1.0]
+    - [FCLASS_D, 1.0]
+    - [FMV_D_X, 1.0]
+    - [FCVT_L_D, 1.0]
+    - [FCVT_LU_D, 1.0]
+    - [FCVT_D_L, 1.0]
+    - [FCVT_D_LU, 1.0]
+    - [FCVT_S_D, 1.0]
+    - [FCVT_D_S, 1.0]
+    - [FLD, 1.0]
+    - [FSD, 1.0]
+
+# CHECK-NOT: f1_f 
+# CHECK-NOT: f2_f 
+# CHECK-NOT: f3_f 
+# CHECK-NOT: f4_f 
+# CHECK-NOT: f5_f 
+# CHECK-NOT: f6_f 
+# CHECK-NOT: f7_f 
+# CHECK-NOT: f8_f 
+# CHECK-NOT: f9_f 
+# CHECK-NOT: f10_f 
+# CHECK-NOT: f11_f 
+# CHECK-NOT: f12_f 
+# CHECK-NOT: f15_f 
+# CHECK-NOT: f16_f 
+# CHECK-NOT: f17_f 
+# CHECK-NOT: f18_f 
+# CHECK-NOT: f19_f 
+# CHECK-NOT: f20_f 
+# CHECK-NOT: f21_f 
+# CHECK-NOT: f22_f 
+# CHECK-NOT: f25_f 
+# CHECK-NOT: f26_f 
+# CHECK-NOT: f27_f 
+# CHECK-NOT: f28_f 
+# CHECK-NOT: f29_f 
+# CHECK-NOT: f30_f 
+# CHECK-NOT: f31_f 
+
+# CHECK-NOT: f1_d 
+# CHECK-NOT: f2_d 
+# CHECK-NOT: f3_d 
+# CHECK-NOT: f4_d 
+# CHECK-NOT: f5_d 
+# CHECK-NOT: f6_d 
+# CHECK-NOT: f7_d 
+# CHECK-NOT: f8_d 
+# CHECK-NOT: f9_d 
+# CHECK-NOT: f10_d 
+# CHECK-NOT: f11_d 
+# CHECK-NOT: f12_d 
+# CHECK-NOT: f15_d 
+# CHECK-NOT: f16_d 
+# CHECK-NOT: f17_d 
+# CHECK-NOT: f18_d 
+# CHECK-NOT: f19_d 
+# CHECK-NOT: f20_d 
+# CHECK-NOT: f21_d 
+# CHECK-NOT: f22_d 
+# CHECK-NOT: f25_d 
+# CHECK-NOT: f26_d 
+# CHECK-NOT: f27_d 
+# CHECK-NOT: f28_d 
+# CHECK-NOT: f29_d 
+# CHECK-NOT: f30_d 
+# CHECK-NOT: f31_d 
+

--- a/llvm/test/tools/llvm-snippy/reserved-regs/FP-reserved-aliases-4.yaml
+++ b/llvm/test/tools/llvm-snippy/reserved-regs/FP-reserved-aliases-4.yaml
@@ -1,0 +1,181 @@
+# COM: This test checks that if registers Fx_H, Fy_F, Fz_D are reserved, 
+# COM: then Fx_H, Fx_F, Fx_D, Fy_H, Fy_F, Fy_D, Fz_H, Fz_F and Fz_D
+# COM: are not found in the machine function dump.
+
+# RUN: llvm-snippy %s -model-plugin=None \
+# RUN:  |& FileCheck %s
+
+options:
+  march: riscv64-linux-gnu
+  mcpu: generic-rv64
+  mattr: +d,+zfh
+  dump-mf: on
+  num-instrs: 10000
+  reserved-regs-list: [F0_H,F1_F,F2_D,F3_H,F4_F,F5_D,F6_H,F7_F,F8_D,F9_H,F10_F,F11_D,F12_H,F13_F,F14_D,F15_H,F16_F,F17_D,F18_H,F19_F,F20_D]
+
+sections:
+    - no:        1
+      VMA:       0x80000000
+      SIZE:      0x400000
+      LMA:       0x80000000
+      ACCESS:    rx
+    - no:        2
+      VMA:       0x80600000
+      SIZE:      0x400000
+      LMA:       0x80600000
+      ACCESS:    rw
+
+histogram:
+    - [FADD_S, 1.0]
+    - [FMSUB_S, 1.0]
+    - [FNMSUB_S, 1.0]
+    - [FNMADD_S, 1.0]
+    - [FADD_S, 1.0]
+    - [FSUB_S, 1.0]
+    - [FMUL_S, 1.0]
+    - [FDIV_S, 1.0]
+    - [FSQRT_S, 1.0]
+    - [FSGNJ_S, 1.0]
+    - [FSGNJN_S, 1.0]
+    - [FSGNJX_S, 1.0]
+    - [FMIN_S, 1.0]
+    - [FMAX_S, 1.0]
+    - [FCVT_W_S, 1.0]
+    - [FCVT_WU_S, 1.0]
+    - [FMV_X_W, 1.0]
+    - [FEQ_S, 1.0]
+    - [FLT_S, 1.0]
+    - [FLE_S, 1.0]
+    - [FCLASS_S, 1.0]
+    - [FCVT_S_W, 1.0]
+    - [FCVT_S_WU, 1.0]
+    - [FMV_W_X, 1.0]
+    - [FCVT_L_S, 1.0]
+    - [FCVT_LU_S, 1.0]
+    - [FCVT_S_L, 1.0]
+    - [FCVT_S_LU, 1.0]
+    - [FLW, 1.0]
+    - [FSW, 1.0]
+
+    - [FMADD_D, 1.0]
+    - [FMSUB_D, 1.0]
+    - [FNMSUB_D, 1.0]
+    - [FNMADD_D, 1.0]
+    - [FADD_D, 1.0]
+    - [FSUB_D, 1.0]
+    - [FMUL_D, 1.0]
+    - [FDIV_D, 1.0]
+    - [FSQRT_D, 1.0]
+    - [FSGNJ_D, 1.0]
+    - [FSGNJN_D, 1.0]
+    - [FSGNJX_D, 1.0]
+    - [FMIN_D, 1.0]
+    - [FMAX_D, 1.0]
+    - [FCVT_W_D, 1.0]
+    - [FCVT_WU_D, 1.0]
+    - [FCVT_D_W, 1.0]
+    - [FCVT_D_WU, 1.0]
+    - [FMV_X_D, 1.0]
+    - [FEQ_D, 1.0]
+    - [FLT_D, 1.0]
+    - [FLE_D, 1.0]
+    - [FCLASS_D, 1.0]
+    - [FMV_D_X, 1.0]
+    - [FCVT_L_D, 1.0]
+    - [FCVT_LU_D, 1.0]
+    - [FCVT_D_L, 1.0]
+    - [FCVT_D_LU, 1.0]
+    - [FCVT_S_D, 1.0]
+    - [FCVT_D_S, 1.0]
+    - [FLD, 1.0]
+    - [FSD, 1.0]
+
+    - [FMADD_H, 1.0]
+    - [FMSUB_H, 1.0]
+    - [FNMSUB_H, 1.0]
+    - [FNMADD_H, 1.0]
+    - [FADD_H, 1.0]
+    - [FSUB_H, 1.0]
+    - [FMUL_H, 1.0]
+    - [FDIV_H, 1.0]
+    - [FSQRT_H, 1.0]
+    - [FSGNJ_H, 1.0]
+    - [FSGNJN_H, 1.0]
+    - [FSGNJX_H, 1.0]
+    - [FMIN_H, 1.0]
+    - [FMAX_H, 1.0]
+    - [FCVT_W_H, 1.0]
+    - [FCVT_WU_H, 1.0]
+    - [FMV_X_H, 1.0]
+    - [FEQ_H, 1.0]
+    - [FLT_H, 1.0]
+    - [FLE_H, 1.0]
+    - [FCLASS_H, 1.0]
+    - [FCVT_H_W, 1.0]
+    - [FCVT_H_WU, 1.0]
+    - [FMV_H_X, 1.0]
+    - [FCVT_L_H, 1.0]
+    - [FCVT_LU_H, 1.0]
+    - [FCVT_H_L, 1.0]
+    - [FCVT_H_LU, 1.0]
+    - [FCVT_S_H, 1.0]
+    - [FCVT_H_S, 1.0]
+    - [FLH, 1.0]
+    - [FSH, 1.0]
+
+# CHECK-NOT: f1_h 
+# CHECK-NOT: f2_h 
+# CHECK-NOT: f3_h 
+# CHECK-NOT: f4_h 
+# CHECK-NOT: f5_h 
+# CHECK-NOT: f6_h 
+# CHECK-NOT: f7_h 
+# CHECK-NOT: f8_h 
+# CHECK-NOT: f9_h 
+# CHECK-NOT: f10_h 
+# CHECK-NOT: f11_h 
+# CHECK-NOT: f12_h 
+# CHECK-NOT: f15_h 
+# CHECK-NOT: f16_h 
+# CHECK-NOT: f17_h 
+# CHECK-NOT: f18_h 
+# CHECK-NOT: f19_h 
+# CHECK-NOT: f20_h 
+
+# CHECK-NOT: f1_f 
+# CHECK-NOT: f2_f 
+# CHECK-NOT: f3_f 
+# CHECK-NOT: f4_f 
+# CHECK-NOT: f5_f 
+# CHECK-NOT: f6_f 
+# CHECK-NOT: f7_f 
+# CHECK-NOT: f8_f 
+# CHECK-NOT: f9_f 
+# CHECK-NOT: f10_f 
+# CHECK-NOT: f11_f 
+# CHECK-NOT: f12_f 
+# CHECK-NOT: f15_f 
+# CHECK-NOT: f16_f 
+# CHECK-NOT: f17_f 
+# CHECK-NOT: f18_f 
+# CHECK-NOT: f19_f 
+# CHECK-NOT: f20_f 
+
+# CHECK-NOT: f1_d 
+# CHECK-NOT: f2_d 
+# CHECK-NOT: f3_d 
+# CHECK-NOT: f4_d 
+# CHECK-NOT: f5_d 
+# CHECK-NOT: f6_d 
+# CHECK-NOT: f7_d 
+# CHECK-NOT: f8_d 
+# CHECK-NOT: f9_d 
+# CHECK-NOT: f10_d 
+# CHECK-NOT: f11_d 
+# CHECK-NOT: f12_d 
+# CHECK-NOT: f15_d 
+# CHECK-NOT: f16_d 
+# CHECK-NOT: f17_d 
+# CHECK-NOT: f18_d 
+# CHECK-NOT: f19_d 
+# CHECK-NOT: f20_d 

--- a/llvm/test/tools/llvm-snippy/reserved-regs/FP-reserved-aliases.yaml
+++ b/llvm/test/tools/llvm-snippy/reserved-regs/FP-reserved-aliases.yaml
@@ -1,0 +1,92 @@
+# COM: This test checks that if registers Fx_D are reserved, 
+# COM: which also contain sub-registers Fx_F, then both of them 
+# COM: are not found in the machine function dump.
+
+# RUN: llvm-snippy %s -model-plugin=None \
+# RUN:  |& FileCheck %s
+
+options:
+  march: riscv64-linux-gnu
+  mcpu: generic-rv64
+  mattr: +f,+d
+  dump-mf: on
+  num-instrs: 10000
+  reserved-regs-list: [F0_D,F1_D,F2_D,F3_D,F4_D,F5_D,F6_D,F7_D,F8_D,F9_D,F10_D,F11_D,F12_D,F13_D,F14_D,F15_D,F16_D,F17_D,F18_D,F19_D,F20_D,F21_D,F22_D,F23_D,F24_D,F25_D,F26_D,F27_D,F28_D,F29_D,F30_D]
+
+sections:
+    - no:        1
+      VMA:       0x80000000
+      SIZE:      0x400000
+      LMA:       0x80000000
+      ACCESS:    rx
+    - no:        2
+      VMA:       0x80600000
+      SIZE:      0x400000
+      LMA:       0x80600000
+      ACCESS:    rw
+
+histogram:
+    - [FADD_S, 1.0]
+
+# CHECK-NOT: f1_f 
+# CHECK-NOT: f2_f 
+# CHECK-NOT: f3_f 
+# CHECK-NOT: f4_f 
+# CHECK-NOT: f5_f 
+# CHECK-NOT: f6_f 
+# CHECK-NOT: f7_f 
+# CHECK-NOT: f8_f 
+# CHECK-NOT: f9_f 
+# CHECK-NOT: f10_f 
+# CHECK-NOT: f11_f 
+# CHECK-NOT: f12_f 
+# CHECK-NOT: f13_f 
+# CHECK-NOT: f14_f 
+# CHECK-NOT: f15_f 
+# CHECK-NOT: f16_f 
+# CHECK-NOT: f17_f 
+# CHECK-NOT: f18_f 
+# CHECK-NOT: f19_f 
+# CHECK-NOT: f20_f 
+# CHECK-NOT: f21_f 
+# CHECK-NOT: f22_f 
+# CHECK-NOT: f23_f 
+# CHECK-NOT: f24_f 
+# CHECK-NOT: f25_f 
+# CHECK-NOT: f26_f 
+# CHECK-NOT: f27_f 
+# CHECK-NOT: f28_f 
+# CHECK-NOT: f29_f 
+# CHECK-NOT: f30_f 
+
+# CHECK-NOT: f1_d 
+# CHECK-NOT: f2_d 
+# CHECK-NOT: f3_d 
+# CHECK-NOT: f4_d 
+# CHECK-NOT: f5_d 
+# CHECK-NOT: f6_d 
+# CHECK-NOT: f7_d 
+# CHECK-NOT: f8_d 
+# CHECK-NOT: f9_d 
+# CHECK-NOT: f10_d 
+# CHECK-NOT: f11_d 
+# CHECK-NOT: f12_d 
+# CHECK-NOT: f13_d 
+# CHECK-NOT: f14_d 
+# CHECK-NOT: f15_d 
+# CHECK-NOT: f16_d 
+# CHECK-NOT: f17_d 
+# CHECK-NOT: f18_d 
+# CHECK-NOT: f19_d 
+# CHECK-NOT: f20_d 
+# CHECK-NOT: f21_d 
+# CHECK-NOT: f22_d 
+# CHECK-NOT: f23_d 
+# CHECK-NOT: f24_d 
+# CHECK-NOT: f25_d 
+# CHECK-NOT: f26_d 
+# CHECK-NOT: f27_d 
+# CHECK-NOT: f28_d 
+# CHECK-NOT: f29_d 
+# CHECK-NOT: f30_d 
+

--- a/llvm/test/tools/llvm-snippy/reserved-regs/Inputs/rvv-unit-all.yaml
+++ b/llvm/test/tools/llvm-snippy/reserved-regs/Inputs/rvv-unit-all.yaml
@@ -1,0 +1,39 @@
+riscv-vector-unit:
+  mode-change-bias:
+    P: 0.2
+  mode-distribution:
+    VM:
+      - [all_ones, 2.0]
+      - [any_legal, 1.0]
+    VL:
+      - [vlmax, 2.0]
+      - [any_legal, 1.0]
+    VXRM:
+      rnu: 1.0
+      rne: 1.0
+      rdn: 1.0
+      ron: 1.0
+    VXSAT:
+      on: 1.0
+      off: 1.0
+    VTYPE:
+      SEW:
+        sew_8: 1.0
+        sew_16: 1.0
+        sew_32: 1.0
+        sew_64: 1.0
+      LMUL:
+        m1: 1.0
+        m2: 1.0
+        m4: 1.0
+        m8: 1.0
+        mf2: 1.0
+        mf4: 1.0
+        mf8: 1.0
+      VMA:
+        mu: 1.0
+        ma: 1.0
+      VTA:
+        tu: 1.0
+        ta: 1.0
+

--- a/llvm/test/tools/llvm-snippy/reserved-regs/Inputs/stack-all-reserved-layout.yaml
+++ b/llvm/test/tools/llvm-snippy/reserved-regs/Inputs/stack-all-reserved-layout.yaml
@@ -1,0 +1,16 @@
+sections:
+    - no:        1
+      VMA:       0x500000
+      SIZE:      0x100000
+      LMA:       0x500000
+      ACCESS:    rx
+    - no:        2
+      VMA:       0x600000
+      SIZE:      0x700000
+      LMA:       0x600000
+      ACCESS:    rw
+
+histogram:
+    - [BEQ, 0.1]
+    - [DIV, 1.0]
+    - [ADD, 1.0]

--- a/llvm/test/tools/llvm-snippy/reserved-regs/reserved-reg-2.yaml
+++ b/llvm/test/tools/llvm-snippy/reserved-regs/reserved-reg-2.yaml
@@ -1,0 +1,43 @@
+# RUN: llvm-snippy %s -march=riscv64-linux-gnu -mattr=+f -init-regs-in-elf \
+# RUN:    -dump-mf -num-instrs=1 -model-plugin=None \
+# RUN:    -reserved-regs-list=X0,X1,X2,X3,X4,X5,X6,X7,X8,X9,X11,X12,X13,X14,X15,X16,X17,X18,X19,X20,X21,X22,X23,X24,X25,X26,X27,X28,X29,X30,X31 \
+# RUN:    | FileCheck %s
+
+# RUN: llvm-snippy %s -march=riscv64-linux-gnu -mattr=+d -init-regs-in-elf \
+# RUN:    -dump-mf -num-instrs=1 -model-plugin=None \
+# RUN:    -reserved-regs-list=X0,X1,X2,X3,X4,X5,X6,X7,X8,X9,X11,X12,X13,X14,X15,X16,X17,X18,X19,X20,X21,X22,X23,X24,X25,X26,X27,X28,X29,X30,X31 \
+# RUN:    | FileCheck %s
+
+# RUN: llvm-snippy %s -march=riscv64-linux-gnu -mattr=+v -init-regs-in-elf \
+# RUN:    -dump-mf -num-instrs=1 -model-plugin=None \
+# RUN:    -reserved-regs-list=X0,X1,X2,X3,X4,X5,X6,X7,X8,X9,X11,X12,X13,X14,X15,X16,X17,X18,X19,X20,X21,X22,X23,X24,X25,X26,X27,X28,X29,X30,X31 \
+# RUN:    | FileCheck %s
+
+sections:
+  - name:      ro
+    VMA:       0x000000
+    SIZE:      0x100000
+    LMA:       0x000000
+    ACCESS:    r
+  - no:        1
+    VMA:       0x100000
+    SIZE:      0x100000
+    LMA:       0x100000
+    ACCESS:    rx
+  - no:        2
+    VMA:       0x200000
+    SIZE:      0x100000
+    LMA:       0x200000
+    ACCESS:    rw
+  - name:      selfcheck
+    VMA:       0x300000
+    SIZE:      0x100000
+    LMA:       0x300000
+    ACCESS:    rw
+
+histogram:
+    - [XOR, 1.0]
+
+# CHECK: Machine code for function
+# COM: check that there are not only x10 register
+# CHECK-COUNT-100: $x{{(([0-9])|(1[1-9])|(2[0-9])|(31))}}

--- a/llvm/test/tools/llvm-snippy/reserved-regs/reserved-reg-alt-names.yaml
+++ b/llvm/test/tools/llvm-snippy/reserved-regs/reserved-reg-alt-names.yaml
@@ -1,0 +1,26 @@
+# RUN: llvm-snippy %s -march=riscv64-linux-gnu -init-regs-in-elf \
+# RUN:    -dump-mi -num-instrs=2000 -reserved-regs-list=x4,s0,ra \
+# RUN:    | FileCheck %s
+
+sections:
+  - no:        1
+    VMA:       0x210000
+    SIZE:      0x40000
+    LMA:       0x210000
+    ACCESS:    rx
+  - no:        2
+    VMA:       0x100000
+    SIZE:      0x100000
+    LMA:       0x100000
+    ACCESS:    rw
+
+histogram:
+    - [ADD, 1.0]
+    - [ADDI, 1.0]
+    - [LW, 1.0]
+    - [SW, 1.0]
+
+# CHECK: Generated
+# CHECK-NOT: $x4
+# CHECK-NOT: $x8
+# CHECK-NOT: $x1{{[^0-9]}}

--- a/llvm/test/tools/llvm-snippy/reserved-regs/reserved-reg-fail.yaml
+++ b/llvm/test/tools/llvm-snippy/reserved-regs/reserved-reg-fail.yaml
@@ -1,0 +1,26 @@
+# RUN: llvm-snippy %s -march=riscv64-linux-gnu -redefine-sp=SP \
+# RUN:    -dump-mi -num-instrs=20000 -reserved-regs-list=X0,X1,X2,X3,X4,X5,\
+# RUN:X6,X7,X8,X9,X10,X11,X12,X13,X14,X15,X16,X17,X18,X19,X20,X21,X22,X23,X24,X25,X26,X27,\
+# RUN:X28,X29,X30,X31 -last-instr= -model-plugin=None >& %t || true
+# RUN: FileCheck --input-file=%t --dump-input always %s
+# RUN: not llvm-snippy %s -march=riscv64-linux-gnu \
+# RUN:    -dump-mi -num-instrs=20000 -reserved-regs-list=X0,X1,X2,XA,X4,\
+# RUN: -last-instr= -model-plugin=None |& FileCheck --dump-input always \
+# RUN:  --check-prefix=ILLEGAL %s
+sections:
+  - no:        1
+    VMA:       0x210000
+    SIZE:      0x1000
+    LMA:       0x210000
+    ACCESS:    rx
+  - no:        2
+    VMA:       0x100000
+    SIZE:      0x100000
+    LMA:       0x100000
+    ACCESS:    rw
+
+histogram:
+    - [ADD, 1.0]
+    - [ADDI, 1.0]
+# CHECK: LLVM ERROR: No available register GPR: instruction generation
+# ILLEGAL: LLVM ERROR: Illegal register name XA is specified in --reserved-regs-list

--- a/llvm/test/tools/llvm-snippy/reserved-regs/reserved-reg-in-yaml.yaml
+++ b/llvm/test/tools/llvm-snippy/reserved-regs/reserved-reg-in-yaml.yaml
@@ -1,0 +1,29 @@
+# RUN: llvm-snippy %s -model-plugin=None | FileCheck %s
+
+options:
+  march: riscv64-unknown-elf
+  mattr: +d
+  dump-mi: true
+  num-instrs: 2000
+  reserved-regs-list: [X4, X6, F1_D]
+sections:
+  - no: 1
+    VMA: 0x210000
+    SIZE: 0x40000
+    LMA: 0x210000
+    ACCESS: rx
+  - no: 2
+    VMA: 0x100000
+    SIZE: 0x100000
+    LMA: 0x100000
+    ACCESS: rw
+histogram:
+  - [ADD, 1.0]
+  - [ADDI, 1.0]
+  - [LW, 1.0]
+  - [SW, 1.0]
+
+# CHECK: Generated
+# CHECK-NOT: $x4
+# CHECK-NOT: $x6
+# CHECK-NOT: $F1_D

--- a/llvm/test/tools/llvm-snippy/reserved-regs/reserved-reg.yaml
+++ b/llvm/test/tools/llvm-snippy/reserved-regs/reserved-reg.yaml
@@ -1,0 +1,27 @@
+# RUN: llvm-snippy %s -march=riscv64-linux-gnu -mattr=+d \
+# RUN:    -dump-mi -num-instrs=2000 -reserved-regs-list=X4,X6,F1_D \
+# RUN:    -last-instr= -model-plugin=None \
+# RUN:    | FileCheck %s
+
+sections:
+  - no:        1
+    VMA:       0x210000
+    SIZE:      0x40000
+    LMA:       0x210000
+    ACCESS:    rx
+  - no:        2
+    VMA:       0x100000
+    SIZE:      0x100000
+    LMA:       0x100000
+    ACCESS:    rw
+
+histogram:
+    - [ADD, 1.0]
+    - [ADDI, 1.0]
+    - [LW, 1.0]
+    - [SW, 1.0]
+
+# CHECK: Generated
+# CHECK-NOT: $x4
+# CHECK-NOT: $x6
+# CHECK-NOT: $F1_D

--- a/llvm/test/tools/llvm-snippy/reserved-regs/rvv-reserved-aliases-2.yaml
+++ b/llvm/test/tools/llvm-snippy/reserved-regs/rvv-reserved-aliases-2.yaml
@@ -1,0 +1,61 @@
+# COM: This test checks that if register aliases are reserved, 
+# COM: then all their sub-register are not found in the machine function dump.
+
+# RUN: llvm-snippy %s -model-plugin=None \
+# RUN:  |& FileCheck %s
+
+options:
+  march: riscv64-linux-gnu
+  mcpu: generic-rv64
+  mattr: +v
+  dump-mf: on
+  riscv-init-vregs-from-memory: on
+  reserved-regs-list: [V0M8,V8M8,V16_V17_V18_V19_V20_V21_V22_V23]
+  num-instrs: 10000
+
+include:
+    - Inputs/rvv-unit-all.yaml
+
+sections:
+    - no:        0
+      VMA:       0x10000
+      SIZE:      0x40000
+      LMA:       0x10000
+      ACCESS:    r
+    - no:        1
+      VMA:       0x100000
+      SIZE:      0x100000
+      LMA:       0x100000
+      ACCESS:    rx
+    - no:        2
+      VMA:       0x210000
+      SIZE:      0x100000
+      LMA:       0x210000
+      ACCESS:    rw
+
+histogram:
+    - [VADD_VV, 1.0]
+
+# CHECK-NOT: {{v1 }}
+# CHECK-NOT: {{v2 }}
+# CHECK-NOT: {{v3 }}
+# CHECK-NOT: v4
+# CHECK-NOT: v5
+# CHECK-NOT: v6
+# CHECK-NOT: v7
+# CHECK-NOT: v8
+# CHECK-NOT: v9
+# CHECK-NOT: v10
+# CHECK-NOT: v11
+# CHECK-NOT: v12
+# CHECK-NOT: v13
+# CHECK-NOT: v14
+# CHECK-NOT: v15
+# CHECK-NOT: v16
+# CHECK-NOT: v17
+# CHECK-NOT: v18
+# CHECK-NOT: v19
+# CHECK-NOT: v20
+# CHECK-NOT: v21
+# CHECK-NOT: v22
+# CHECK-NOT: v23

--- a/llvm/test/tools/llvm-snippy/reserved-regs/rvv-reserved-aliases.yaml
+++ b/llvm/test/tools/llvm-snippy/reserved-regs/rvv-reserved-aliases.yaml
@@ -1,0 +1,91 @@
+# COM: This test checks that if registers {V3, V5, V7, ...} are reserved, 
+# COM: which are sub-registers of {V2_V3, V4_V5, V6_V7, ...} when LMUL == 2,
+# COM: then these registers are not taken. It means that {V2, V4, V6, ...}
+# COM: do not found in the machine function dump.
+
+# RUN: llvm-snippy %s -model-plugin=None \
+# RUN: |& FileCheck %s --dump-input always
+
+options:
+  march: riscv64-linux-gnu
+  mcpu: generic-rv64
+  mattr: +v
+  dump-mf: on
+  num-instrs: 10000
+  reserved-regs-list: [V3,V5,V7,V9,V11,V13,V15,V17,V19,V21,V23]
+
+riscv-vector-unit:
+  mode-change-bias:
+    P: 0.5
+  mode-distribution:
+    VM:
+      - [all_ones, 2.0]
+      - [any_legal, 1.0]
+    VL:
+      - [vlmax, 2.0]
+      - [any_legal, 1.0]
+    VXRM:
+      rnu: 1.0
+      rne: 1.0
+      rdn: 1.0
+      ron: 1.0
+    VXSAT:
+      on: 1.0
+      off: 1.0
+    VTYPE:
+      SEW:
+        sew_8: 1.0
+        sew_16: 1.0
+        sew_32: 1.0
+        sew_64: 1.0
+      LMUL:
+        m2: 1.0
+      VMA:
+        mu: 1.0
+        ma: 1.0
+      VTA:
+        tu: 1.0
+        ta: 1.0
+
+sections:
+    - no:        0
+      VMA:       0x10000
+      SIZE:      0x40000
+      LMA:       0x10000
+      ACCESS:    r
+    - no:        1
+      VMA:       0x100000
+      SIZE:      0x100000
+      LMA:       0x100000
+      ACCESS:    rx
+    - no:        2
+      VMA:       0x210000
+      SIZE:      0x100000
+      LMA:       0x210000
+      ACCESS:    rw
+
+histogram: 
+    - [VADD_VV, 1.0]
+
+# CHECK-NOT: {{v2 }}
+# CHECK-NOT: {{v3 }}
+# CHECK-NOT: v4
+# CHECK-NOT: v5
+# CHECK-NOT: v6
+# CHECK-NOT: v7
+# CHECK-NOT: v8
+# CHECK-NOT: v9
+# CHECK-NOT: v10
+# CHECK-NOT: v11
+# CHECK-NOT: v12
+# CHECK-NOT: v13
+# CHECK-NOT: v14
+# CHECK-NOT: v15
+# CHECK-NOT: v16
+# CHECK-NOT: v17
+# CHECK-NOT: v18
+# CHECK-NOT: v19
+# CHECK-NOT: v20
+# CHECK-NOT: v21
+# CHECK-NOT: v22
+# CHECK-NOT: v23

--- a/llvm/test/tools/llvm-snippy/reserved-regs/stack-all-reserved.yaml
+++ b/llvm/test/tools/llvm-snippy/reserved-regs/stack-all-reserved.yaml
@@ -1,0 +1,5 @@
+# RUN: llvm-snippy %s -march=riscv64-linux-gnu -mattr=+m,+c \
+# RUN:    %S/Inputs/stack-all-reserved-layout.yaml \
+# RUN:   -num-instrs=10000 -stack-size=1024  \
+# RUN:   --reserved-regs-list=X1,X3,X4,X8,X9,X10,X11,X12,X13,X14,X15,X16,X17,X18,X19,X20,X21,X22,X23,X24,X25,X26,X27,X29,X30,X31 \
+# RUN:   --spilled-regs-list=X5,X6,X7,X28 -init-regs-in-elf -verify-mi

--- a/llvm/tools/llvm-snippy/include/snippy/Generator/AccessMaskBit.h
+++ b/llvm/tools/llvm-snippy/include/snippy/Generator/AccessMaskBit.h
@@ -1,0 +1,46 @@
+#ifndef LLVM_TOOLS_SNIPPY_ACCESS_MASK_BIT_H
+#define LLVM_TOOLS_SNIPPY_ACCESS_MASK_BIT_H
+
+//===-- AccessMaskBit.h -----------------------------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+namespace llvm {
+namespace snippy {
+
+#ifdef LLVM_SNIPPY_ACCESS_MASKS
+#error LLVM_SNIPPY_ACCESS_MASKS is already defined
+#endif
+#define LLVM_SNIPPY_ACCESS_MASKS                                               \
+  LLVM_SNIPPY_ACCESS_MASK_DESC(None, 0b0000)                                   \
+  LLVM_SNIPPY_ACCESS_MASK_DESC(SR, 0b0001)                                     \
+  LLVM_SNIPPY_ACCESS_MASK_DESC(GR, 0b0010)                                     \
+  LLVM_SNIPPY_ACCESS_MASK_DESC(R, 0b0011)                                      \
+  LLVM_SNIPPY_ACCESS_MASK_DESC(SW, 0b0100)                                     \
+  LLVM_SNIPPY_ACCESS_MASK_DESC(GW, 0b1000)                                     \
+  LLVM_SNIPPY_ACCESS_MASK_DESC(W, 0b1100)                                      \
+  LLVM_SNIPPY_ACCESS_MASK_DESC(SRW, 0b0101)                                    \
+  LLVM_SNIPPY_ACCESS_MASK_DESC(GRW, 0b1010)                                    \
+  LLVM_SNIPPY_ACCESS_MASK_DESC(RW, 0b1111)
+
+// R - read.
+// W - write.
+// S - support instruction only.
+// G - general instruction only.
+enum class AccessMaskBit {
+#ifdef LLVM_SNIPPY_ACCESS_MASK_DESC
+#error LLVM_SNIPPY_ACCESS_MASK_DESC is already defined
+#endif
+#define LLVM_SNIPPY_ACCESS_MASK_DESC(KEY, VALUE) KEY = VALUE,
+  LLVM_SNIPPY_ACCESS_MASKS
+#undef LLVM_SNIPPY_ACCESS_MASK_DESC
+};
+
+} // namespace snippy
+} // namespace llvm
+
+#endif // LLVM_TOOLS_SNIPPY_ACCESS_MASK_BIT_H

--- a/llvm/tools/llvm-snippy/include/snippy/Generator/GeneratorContext.h
+++ b/llvm/tools/llvm-snippy/include/snippy/Generator/GeneratorContext.h
@@ -351,7 +351,10 @@ public:
   auto &getSelfcheckSection() const { return SelfcheckSection; }
 
   // We return by value here to enforce copy
-  RegPoolWrapper getRegisterPool() { return {RegPoolsStorage}; }
+  RegPoolWrapper getRegisterPool() {
+    assert(State);
+    return {State->getSnippyTarget(), State->getRegInfo(), RegPoolsStorage};
+  }
 
   Linker &getLinker() const { return *PLinker; }
   RegisterGenerator &getRegGen() const { return *RegGen; }

--- a/llvm/tools/llvm-snippy/include/snippy/Generator/Policy.h
+++ b/llvm/tools/llvm-snippy/include/snippy/Generator/Policy.h
@@ -66,7 +66,6 @@
 #include "snippy/Config/ImmediateHistogram.h"
 #include "snippy/Config/OpcodeHistogram.h"
 #include "snippy/Generator/GenerationLimit.h"
-#include "snippy/Generator/RegisterPool.h"
 #include "snippy/Generator/SelfCheckInfo.h"
 #include "snippy/Support/OpcodeGenerator.h"
 
@@ -77,6 +76,7 @@ namespace llvm {
 namespace snippy {
 
 class GeneratorContext;
+class RegPoolWrapper;
 namespace planning {
 
 // Helper class to keep additional information about the operand: register

--- a/llvm/tools/llvm-snippy/include/snippy/Target/Target.h
+++ b/llvm/tools/llvm-snippy/include/snippy/Target/Target.h
@@ -19,8 +19,9 @@
 
 #include "snippy/Config/MemoryScheme.h"
 #include "snippy/Config/OpcodeHistogram.h"
+#include "snippy/Generator/AccessMaskBit.h"
 #include "snippy/Generator/MemoryManager.h"
-#include "snippy/Generator/RegisterPool.h"
+#include "snippy/Generator/Policy.h"
 #include "snippy/PassManagerWrapper.h"
 #include "snippy/Simulator/Simulator.h"
 #include "snippy/Support/DynLibLoader.h"

--- a/llvm/tools/llvm-snippy/lib/Generator/RegisterPool.cpp
+++ b/llvm/tools/llvm-snippy/lib/Generator/RegisterPool.cpp
@@ -175,7 +175,7 @@ void RegPool::addReserved(unsigned Reg, AccessMaskBit AccessMask) {
              << "\n");
 }
 
-void RegPool::addReserved(const MachineFunction &MF, unsigned Reg,
+void RegPool::addReserved(unsigned Reg, const MachineFunction &MF,
                           AccessMaskBit AccessMask) {
   ReservedForFunction[&MF].addReserved(Reg, AccessMask);
   LLVM_DEBUG(
@@ -186,10 +186,10 @@ void RegPool::addReserved(const MachineFunction &MF, unsigned Reg,
              << "\n");
 }
 
-void RegPool::addReserved(const MachineLoop &ML, unsigned Reg,
+void RegPool::addReserved(unsigned Reg, const MachineLoop &ML,
                           AccessMaskBit AccessMask) {
   for_each(ML.blocks(), [this, Reg, AccessMask](auto *MBB) {
-    addReserved(*MBB, Reg, AccessMask);
+    addReserved(Reg, *MBB, AccessMask);
   });
   LLVM_DEBUG(
       dbgs() << "Reserved reg [" << Reg << "] for ML with access mask "
@@ -198,7 +198,7 @@ void RegPool::addReserved(const MachineLoop &ML, unsigned Reg,
              << "\n");
 }
 
-void RegPool::addReserved(const MachineBasicBlock &MBB, unsigned Reg,
+void RegPool::addReserved(unsigned Reg, const MachineBasicBlock &MBB,
                           AccessMaskBit AccessMask) {
   ReservedForBlock[&MBB].addReserved(Reg, AccessMask);
   LLVM_DEBUG(

--- a/llvm/tools/llvm-snippy/lib/LoopLatcherPass.cpp
+++ b/llvm/tools/llvm-snippy/lib/LoopLatcherPass.cpp
@@ -255,8 +255,8 @@ auto LoopLatcher::selectRegsForBranch(const MachineLoop &ML,
       "for loop latch", RegInfo, RegClass, MBBsForReserv, Filter,
       AccessMaskBit::SRW);
 
-  RootPool.addReserved(Preheader, Counter, AccessMaskBit::W);
-  RootPool.addReserved(Preheader, Limit, AccessMaskBit::W);
+  RootPool.addReserved(Counter, Preheader, AccessMaskBit::W);
+  RootPool.addReserved(Limit, Preheader, AccessMaskBit::W);
   auto TrackingMode = SGCtx.hasTrackingMode();
   if (UseStackOpt || TrackingMode) {
     // We still have to reserve counter register even when using the stack.
@@ -264,12 +264,12 @@ auto LoopLatcher::selectRegsForBranch(const MachineLoop &ML,
     // flow generator (or any other part of snippy) and we'll corrupt the data
     // stored in it. Reservation can be smaller though - only one block.
     auto ReservationMode = TrackingMode ? AccessMaskBit::RW : AccessMaskBit::W;
-    RootPool.addReserved(ExitingBlock, Counter, ReservationMode);
-    RootPool.addReserved(ExitingBlock, Limit, ReservationMode);
+    RootPool.addReserved(Counter, ExitingBlock, ReservationMode);
+    RootPool.addReserved(Limit, ExitingBlock, ReservationMode);
   } else {
     for (const auto *MBB : MBBsForReserv) {
-      RootPool.addReserved(*MBB, Counter, AccessMaskBit::W);
-      RootPool.addReserved(*MBB, Limit, AccessMaskBit::W);
+      RootPool.addReserved(Counter, *MBB, AccessMaskBit::W);
+      RootPool.addReserved(Limit, *MBB, AccessMaskBit::W);
     }
   }
   return std::make_pair(Counter, Limit);

--- a/llvm/tools/llvm-snippy/llvm-snippy.cpp
+++ b/llvm/tools/llvm-snippy/llvm-snippy.cpp
@@ -596,7 +596,10 @@ static void parseReservedRegistersOption(RegPool &RP, const SnippyTarget &Tgt,
                              " is specified in --" +
                              ReservedRegisterList.ArgStr,
                          false);
-    RP.addReserved(Reg.value(), AccessMaskBit::GRW);
+    llvm::for_each(Tgt.getPhysRegsFromUnit(Reg.value(), RI),
+                   [&RP](auto SimpleReg) {
+                     RP.addReserved(SimpleReg, AccessMaskBit::GRW);
+                   });
     DEBUG_WITH_TYPE("snippy-regpool",
                     (dbgs() << "Reserved with option:\n", RP.print(dbgs())));
   }


### PR DESCRIPTION
To solve the problem with register reservation,
it was necessary to prohibit the reservation of non-physical registers.