### PR TITLE
[snippy] Account spill of the real stack pointer

### DIFF
--- a/llvm/tools/llvm-snippy/include/snippy/Generator/SnippyModule.h
+++ b/llvm/tools/llvm-snippy/include/snippy/Generator/SnippyModule.h
@@ -143,6 +143,11 @@ public:
 
   bool followTargetABI() const { return FollowTargetABI; }
 
+  // When an arbitrary register is used as a stack pointer and this register
+  // must be preserved across snippy function call (callee-saved), we have to
+  // save it to the stack before start using it.
+  bool shouldSpillStackPointer() const;
+
 private:
   friend RootRegPoolWrapper;
   void initializeStackSection(const SnippyProgramSettings &Settings);

--- a/llvm/tools/llvm-snippy/lib/FlowGenerator.cpp
+++ b/llvm/tools/llvm-snippy/lib/FlowGenerator.cpp
@@ -205,6 +205,9 @@ static size_t calcMainFuncInitialSpillSize(GeneratorContext &GC) {
 
   auto StackPointer = GC.getProgramContext().getStackPointer();
   size_t SpillSize = SnippyTgt.getSpillAlignmentInBytes(StackPointer, State);
+  // We'll spill a register we use as a stack pointer.
+  if (GC.getProgramContext().shouldSpillStackPointer())
+    SpillSize += SnippyTgt.getSpillSizeInBytes(StackPointer, GC);
 
   auto SpilledRef = GC.getRegsSpilledToStack();
   std::vector SpilledRegs(SpilledRef.begin(), SpilledRef.end());

--- a/llvm/tools/llvm-snippy/lib/Generator/SnippyModule.cpp
+++ b/llvm/tools/llvm-snippy/lib/Generator/SnippyModule.cpp
@@ -134,6 +134,18 @@ std::string SnippyProgramContext::generateLinkedImage(
   return PLinker->run(Objects, /*Relocatable*/ false);
 }
 
+bool SnippyProgramContext::shouldSpillStackPointer() const {
+  if (!followTargetABI())
+    return false;
+  auto RealStackPointer = getStackPointer();
+  const auto &SnippyTgt = getLLVMState().getSnippyTarget();
+  auto ABIPreservedRegs = SnippyTgt.getRegsPreservedByABI();
+  return std::any_of(ABIPreservedRegs.begin(), ABIPreservedRegs.end(),
+                     [RealStackPointer](auto PreservedReg) {
+                       return PreservedReg == RealStackPointer;
+                     });
+}
+
 void SnippyProgramContext::initializeStackSection(
     const SnippyProgramSettings &Settings) {
   if (!Settings.Sections.hasSection(SectionsDescriptions::StackSectionName))


### PR DESCRIPTION
[snippy] Account spill of the real stack pointer

Stack pointer role can be given to an arbitrary callee-saved register. In this
case a spill (and fill) of this register is necessary. This spill must be
accounted when we initialize a model for a tracking mode (selfcheck, backtrack,
data hazards).