### PR TITLE
[snippy] Improve diagnostics when section start is not a multiply of loop alignment

### DIFF
--- a/llvm/test/tools/llvm-snippy/branches/sections-bad-alignment.yaml
+++ b/llvm/test/tools/llvm-snippy/branches/sections-bad-alignment.yaml
@@ -1,0 +1,28 @@
+# RUN: not llvm-snippy %s -march=riscv64-linux-gnu \
+# RUN:     -num-instrs=50 |& FileCheck %s
+
+sections:
+    - no:        1
+      VMA:       0x1008
+      SIZE:      0x10000
+      LMA:       0x1008
+      ACCESS:    rx
+    - no:        2
+      VMA:       0x80000000
+      SIZE:      0x400000
+      LMA:       0x80000000
+      ACCESS:    rw
+
+histogram:
+    - [BEQ, 1.0]
+    - [BLT, 1.0]
+    - [BLTU, 1.0]
+    - [BGE, 1.0]
+    - [BGEU, 1.0]
+    - [BNE, 1.0]
+    - [AND, 8.0]
+
+branches:
+  alignment: 16
+
+# CHECK: error: LLVM ERROR: Incorrect section: The executable section '1' must be aligned to 16 according to specified config

--- a/llvm/tools/llvm-snippy/include/snippy/Config/MemoryScheme.h
+++ b/llvm/tools/llvm-snippy/include/snippy/Config/MemoryScheme.h
@@ -689,8 +689,8 @@ struct SectionsDescriptions : private std::vector<SectionDesc> {
 };
 
 template <typename SecIt>
-void diagnoseXSections(LLVMContext &Ctx, SecIt SectionsStart,
-                       SecIt SectionsFin) {
+void diagnoseXSections(LLVMContext &Ctx, SecIt SectionsStart, SecIt SectionsFin,
+                       size_t Alignment) {
   // TODO: assert for 1 rx section?
   std::vector<SectionDesc> ExecSections;
   std::copy_if(SectionsStart, SectionsFin, std::back_inserter(ExecSections),
@@ -716,6 +716,13 @@ void diagnoseXSections(LLVMContext &Ctx, SecIt SectionsStart,
           "The executable section " + Twine(ExecSection.getIDString()) +
               " has also W access mode. Snippy does not support SMC for now");
     }
+
+    if (ExecSection.VMA % Alignment)
+      snippy::fatal(Ctx, "Incorrect section",
+                    "The executable section '" +
+                        Twine(ExecSection.getIDString()) +
+                        "' must be aligned to " + Twine(Alignment) +
+                        " according to specified config");
   }
 }
 

--- a/llvm/tools/llvm-snippy/llvm-snippy.cpp
+++ b/llvm/tools/llvm-snippy/llvm-snippy.cpp
@@ -897,7 +897,8 @@ static void checkConfig(const Config &Cfg, const SnippyTarget &Tgt,
       }))
     snippy::fatal(Ctx, "Incorrect list of sections",
                   "List contains duplicate section IDs");
-  diagnoseXSections(Ctx, Cfg.Sections.begin(), Cfg.Sections.end());
+  diagnoseXSections(Ctx, Cfg.Sections.begin(), Cfg.Sections.end(),
+                    Cfg.Branches.Alignment);
 
   if (Cfg.Sections.size() < 2)
     return;


### PR DESCRIPTION
[snippy] Improve diagnostics when section start is not a multiply of loop alignment