### PR TITLE
[snippy][perf]: Remove linear lookups for snippy options

### DIFF
--- a/llvm/tools/llvm-snippy/lib/Support/Options.cpp
+++ b/llvm/tools/llvm-snippy/lib/Support/Options.cpp
@@ -34,7 +34,7 @@ void yaml::CustomMappingTraits<OptionsStorage>::inputOne(
 void yaml::CustomMappingTraits<OptionsStorage>::output(
     yaml::IO &IO, OptionsStorage &Options) {
   for (auto &&Base : Options)
-    Base.first->mapStoredValue(IO);
+    Base.second->mapStoredValue(IO);
 }
 void CommandOptionBase::mapStoredValue(yaml::IO &IO,
                                        std::optional<StringRef> Key) {


### PR DESCRIPTION
[snippy][perf]: Remove linear lookups for snippy options

As it turns out snippy spends a lot of time (~30%) in hot loops
looking up options values. This is a huge performance regression introduced in
by option aliases. Implementing this as a `std::unordered_map<StringRef, std::shared_ptr<_>>`
alleviates the problem.

Additionally this patch gets rid of unnecessary allocations in `std::string`
by using `StringRef` to store option names. They are already required to be static lifetime
since `snippy::opt` (and cosequently `cl::opt`) takes names by `const char *`.

This trivially improves snippy runtime by up to 60% (18s -> 7s) on some tests.