### PR TITLE
[snippy]: Detailed float overwrite value configuration  (revived)

### DIFF
--- a/llvm/test/tools/llvm-snippy/floating-point/float-nan-propagation-disabled.yaml
+++ b/llvm/test/tools/llvm-snippy/floating-point/float-nan-propagation-disabled.yaml
@@ -1,0 +1,21 @@
+# RUN: llvm-snippy %s --model-plugin None | FileCheck %s
+
+include:
+  - ../Inputs/sections.yaml
+options:
+  march: riscv64-unknown-elf
+  mcpu: generic-rv64
+  mattr: "+d"
+  num-instrs: 100
+  dump-mf: true
+fpu-config:
+  overwrite:
+    range:
+      min: 1
+      max: 1
+      rounding-mode: rdn
+    mode: disabled
+histogram:
+  - [FMUL_D, 1.0]
+
+# CHECK-NOT: FMV_D_X

--- a/llvm/test/tools/llvm-snippy/floating-point/float-nan-propagation-error-bit-values-negative-value-ranges.yaml
+++ b/llvm/test/tools/llvm-snippy/floating-point/float-nan-propagation-error-bit-values-negative-value-ranges.yaml
@@ -1,0 +1,20 @@
+# RUN: not llvm-snippy %s --model-plugin None |& FileCheck %s
+
+include:
+  - ../Inputs/sections.yaml
+options:
+  march: riscv64-unknown-elf
+  mcpu: generic-rv64
+  mattr: "+d"
+  num-instrs: 10
+fpu-config:
+  overwrite:
+    ieee-double:
+      valuegram:
+        - type: bitrange
+          min: -1
+          max: 0
+histogram:
+  - [FADD_D, 1.0]
+
+# CHECK: float-nan-propagation-error-bit-values-negative-value-ranges.yaml:14:11: error: Value can't be negative

--- a/llvm/test/tools/llvm-snippy/floating-point/float-nan-propagation-error-bit-values-negative-value.yaml
+++ b/llvm/test/tools/llvm-snippy/floating-point/float-nan-propagation-error-bit-values-negative-value.yaml
@@ -1,0 +1,19 @@
+# RUN: not llvm-snippy %s --model-plugin None |& FileCheck %s
+
+include:
+  - ../Inputs/sections.yaml
+options:
+  march: riscv64-unknown-elf
+  mcpu: generic-rv64
+  mattr: "+d"
+  num-instrs: 10
+fpu-config:
+  overwrite:
+    ieee-double:
+      valuegram:
+        - type: bitvalue
+          value: -1
+histogram:
+  - [FADD_D, 1.0]
+
+# CHECK: float-nan-propagation-error-bit-values-negative-value.yaml:13:7: error: Negative values are not allowed in a valuegram

--- a/llvm/test/tools/llvm-snippy/floating-point/float-nan-propagation-error-integral-range-rounding-mode.yaml
+++ b/llvm/test/tools/llvm-snippy/floating-point/float-nan-propagation-error-integral-range-rounding-mode.yaml
@@ -1,0 +1,19 @@
+# RUN: not llvm-snippy %s --model-plugin None |& FileCheck %s
+
+include:
+  - ../Inputs/sections.yaml
+options:
+  march: riscv64-unknown-elf
+  mcpu: generic-rv64
+  mattr: "+d"
+  num-instrs: 10
+fpu-config:
+  overwrite:
+    range:
+      min: 0
+      max: 0
+      rounding-mode: really-not-a-rounding-mode
+histogram:
+  - [ADDI, 1.0]
+
+# CHECK: float-nan-propagation-error-integral-range-rounding-mode.yaml:15:22: error: unknown enumerated scalar

--- a/llvm/test/tools/llvm-snippy/floating-point/float-nan-propagation-error-ranges-too-large.yaml
+++ b/llvm/test/tools/llvm-snippy/floating-point/float-nan-propagation-error-ranges-too-large.yaml
@@ -1,0 +1,20 @@
+# RUN: not llvm-snippy %s --model-plugin None |& FileCheck %s
+
+include:
+  - ../Inputs/sections.yaml
+options:
+  march: riscv64-unknown-elf
+  mcpu: generic-rv64
+  mattr: "+f,-d"
+  num-instrs: 10
+fpu-config:
+  overwrite:
+    ieee-single:
+      valuegram:
+        - type: bitrange
+          min: 0xffffffffffffffff
+          max: 0xffffffffffffffff
+histogram:
+  - [FMUL_S, 1.0]
+
+# CHECK: float-nan-propagation-error-ranges-too-large.yaml:12:5: error: '0xffffffffffffffff' is too wide to fit in 32 bits

--- a/llvm/test/tools/llvm-snippy/floating-point/float-nan-propagation-error-too-large.yaml
+++ b/llvm/test/tools/llvm-snippy/floating-point/float-nan-propagation-error-too-large.yaml
@@ -1,0 +1,22 @@
+# RUN: not llvm-snippy %s --model-plugin None |& FileCheck %s
+
+include:
+  - ../Inputs/sections.yaml
+options:
+  march: riscv64-unknown-elf
+  mcpu: generic-rv64
+  mattr: "+zfh"
+  num-instrs: 100
+fpu-config:
+  overwrite:
+    ieee-half:
+      valuegram:
+        - [0xfefe, 1.0]
+    range:
+      min: 0xffffffffffff
+      max: 0xffffffffffff
+      rounding-mode: rmm
+histogram:
+  - [FMUL_H, 1.0]
+
+# CHECK: float-nan-propagation-error-too-large.yaml:12:5: error: Conversion from integer value '0xffffffffffff' would result in a floating-point overflow exception

--- a/llvm/test/tools/llvm-snippy/floating-point/float-nan-propagation-error-values-too-large.yaml
+++ b/llvm/test/tools/llvm-snippy/floating-point/float-nan-propagation-error-values-too-large.yaml
@@ -1,0 +1,18 @@
+# RUN: not llvm-snippy %s --model-plugin None |& FileCheck %s
+
+include:
+  - ../Inputs/sections.yaml
+options:
+  march: riscv64-unknown-elf
+  mcpu: generic-rv64
+  mattr: "+f,-d"
+  num-instrs: 10
+fpu-config:
+  overwrite:
+    ieee-single:
+      valuegram:
+        - [0xffffffffffffffff, 1.0]
+histogram:
+  - [FMUL_S, 1.0]
+
+# CHECK: float-nan-propagation-error-values-too-large.yaml:12:5: error: '0xffffffffffffffff' is too wide to fit in 32 bits

--- a/llvm/test/tools/llvm-snippy/floating-point/float-nan-propagation-error.yaml
+++ b/llvm/test/tools/llvm-snippy/floating-point/float-nan-propagation-error.yaml
@@ -1,0 +1,18 @@
+# RUN: not llvm-snippy %s --model-plugin None |& FileCheck %s
+
+include:
+  - ../Inputs/sections.yaml
+options:
+  march: riscv64-unknown-elf
+  mcpu: generic-rv64
+  mattr: "+d"
+  num-instrs: 10
+fpu-config:
+  overwrite:
+    range:
+      min: 3
+      max: 1
+histogram:
+  - [FMUL_D, 1.0]
+
+# CHECK: float-nan-propagation-error.yaml:13:7: error: 'max' should be greater or equal to 'min'

--- a/llvm/test/tools/llvm-snippy/floating-point/float-nan-propagation-extended-overwrite-value-configuration.yaml
+++ b/llvm/test/tools/llvm-snippy/floating-point/float-nan-propagation-extended-overwrite-value-configuration.yaml
@@ -1,0 +1,36 @@
+# RUN: llvm-snippy %s --model-plugin None | FileCheck %s
+
+include:
+  - ../Inputs/sections.yaml
+options:
+  march: riscv64-unknown-elf
+  mcpu: generic-rv64
+  mattr: "+d"
+  num-instrs: 100
+  dump-mf: true
+fpu-config:
+  overwrite:
+    ieee-double:
+      valuegram:
+        - [0x000fffffffffffff, 1.0]
+        - [0x8010000000000000, 1.0]
+        - [0x7ff0000000000000, 1.0]
+        - [uniform, 1.0]
+        - [bitpattern, 1.0]
+        - type: bitrange
+          min: 0x8000000000000001
+          max: 0x800fffffffffffff
+          weight: 1.0
+    range:
+      min: 0x00000000
+      max: 0x0fffffff
+      weight: 2.0
+histogram:
+  - [FMUL_D, 1.0]
+
+# regex to match the following code:
+# REG = FMUL_D ...
+# ... ADDI ...
+# ... SLLI ...
+# REG = FMV_D_X
+# CHECK: [[REG:\$f[[:digit:]]+_d]] = FMUL_D {{.*([[:space:]]+).*ADDI.*([[:space:]]+).*SLLI.*([[:space:]]+)}} [[REG]] = FMV_D_X

--- a/llvm/test/tools/llvm-snippy/floating-point/float-nan-propagation-integral-range-all-rounding-modes.yaml
+++ b/llvm/test/tools/llvm-snippy/floating-point/float-nan-propagation-integral-range-all-rounding-modes.yaml
@@ -1,0 +1,66 @@
+# RUN: sed 's/rm-placeholder/rne/' %s > %t.rne.yaml
+# RUN: llvm-snippy %t.rne.yaml %S/../Inputs/sections.yaml --model-plugin None |& \
+# RUN:   FileCheck %s --check-prefix RNE
+
+# RUN: sed 's/rm-placeholder/rmm/' %s > %t.rmm.yaml
+# RUN: llvm-snippy %t.rmm.yaml %S/../Inputs/sections.yaml --model-plugin None |& \
+# RUN:   FileCheck %s --check-prefix RMM
+
+# RUN: sed 's/rm-placeholder/rdn/' %s > %t.rdn.yaml
+# RUN: llvm-snippy %t.rdn.yaml %S/../Inputs/sections.yaml --model-plugin None |& \
+# RUN:   FileCheck %s --check-prefix RDN
+
+# RUN: sed 's/rm-placeholder/rup/' %s > %t.rup.yaml
+# RUN: llvm-snippy %t.rup.yaml %S/../Inputs/sections.yaml --model-plugin None |& \
+# RUN:   FileCheck %s --check-prefix RUP
+
+# RUN: sed 's/rm-placeholder/rtz/' %s > %t.rtz.yaml
+# RUN: llvm-snippy %t.rtz.yaml %S/../Inputs/sections.yaml --model-plugin None |& \
+# RUN:   FileCheck %s --check-prefix RTZ
+
+# RUN: sed 's/rm-placeholder/toward-zero/' %s > %t.toward-zero.yaml
+# RUN: llvm-snippy %t.toward-zero.yaml %S/../Inputs/sections.yaml --model-plugin None |& \
+# RUN:   FileCheck %s --check-prefix RTZ
+
+# RUN: sed 's/rm-placeholder/toward-positive/' %s > %t.toward-positive.yaml
+# RUN: llvm-snippy %t.toward-positive.yaml %S/../Inputs/sections.yaml --model-plugin None |& \
+# RUN:   FileCheck %s --check-prefix RUP
+
+# RUN: sed 's/rm-placeholder/toward-negative/' %s > %t.toward-negative.yaml
+# RUN: llvm-snippy %t.toward-negative.yaml %S/../Inputs/sections.yaml --model-plugin None |& \
+# RUN:   FileCheck %s --check-prefix RDN
+
+# RUN: sed 's/rm-placeholder/nearest-ties-to-even/' %s > %t.nearest-ties-to-even.yaml
+# RUN: llvm-snippy %t.nearest-ties-to-even.yaml %S/../Inputs/sections.yaml --model-plugin None |& \
+# RUN:   FileCheck %s --check-prefix RNE
+
+# RUN: sed 's/rm-placeholder/nearest-ties-to-away/' %s > %t.nearest-ties-to-away.yaml
+# RUN: llvm-snippy %t.nearest-ties-to-away.yaml %S/../Inputs/sections.yaml --model-plugin None |& \
+# RUN:   FileCheck %s --check-prefix RMM
+
+# RUN: sed 's/rm-placeholder/totally-not-rounding-mode/' %s > %t.totally-not-rounding-mode.yaml
+# RUN: not llvm-snippy %t.totally-not-rounding-mode.yaml %S/../Inputs/sections.yaml --model-plugin None |& \
+# RUN:   FileCheck %s --check-prefix INVALID
+
+options:
+  march: riscv64-unknown-elf
+  mcpu: generic-rv64
+  mattr: "+d"
+  num-instrs: 10
+  dump-layout: true
+fpu-config:
+  overwrite:
+    range:
+      min: 1
+      max: 1
+      rounding-mode: rm-placeholder
+histogram:
+  - [FMUL_D, 1.0]
+
+# RNE: rounding-mode: nearest-ties-to-even
+# RMM: rounding-mode: nearest-ties-to-away
+# RDN: rounding-mode: toward-negative
+# RUP: rounding-mode: toward-positive
+# RTZ: rounding-mode: toward-zero
+
+# INVALID: error: unknown enumerated scalar

--- a/llvm/test/tools/llvm-snippy/floating-point/float-nan-propagation-stress.yaml
+++ b/llvm/test/tools/llvm-snippy/floating-point/float-nan-propagation-stress.yaml
@@ -1,0 +1,135 @@
+# RUN: llvm-snippy %s --model-plugin None |& FileCheck %s
+
+include:
+  - ../Inputs/sections.yaml
+options:
+  march: riscv64-unknown-elf
+  mcpu: generic-rv64
+  mattr: "+d"
+  num-instrs: 10000
+fpu-config:
+  overwrite:
+    range:
+      min: -9223372036854775808
+      max: 9223372036854775807
+      weight: 1.0
+      rounding-mode: rup
+    ieee-single:
+      valuegram:
+        - [0x7f800000, 1.0]
+        - [0xff800000, 1.0]
+        - [0x00000000, 1.0]
+        - [0x80000000, 1.0]
+        - [0x7fc00000, 1.0]
+        - [0x007fffff, 1.0]
+        - [0x00000001, 1.0]
+        - [0x807fffff, 1.0]
+        - [0x80000001, 1.0]
+        - [0x7f7fffff, 1.0]
+        - [0x00800000, 1.0]
+        - [0xff7fffff, 1.0]
+        - [0x80800000, 1.0]
+        - type: bitrange
+          min: 0x00800000
+          max: 0x7f7fffff
+        - type: bitrange
+          min: 0x80800000
+          max: 0xff7fffff
+        - type: bitrange
+          min: 0x00000001
+          max: 0x007fffff
+        - type: bitrange
+          min: 0x80000001
+          max: 0x807fffff
+    ieee-double:
+      valuegram:
+        - [0x7ff0000000000000, 1.0]
+        - [0xfff0000000000000, 1.0]
+        - [0x0000000000000000, 1.0]
+        - [0x8000000000000000, 1.0]
+        - [0x7ff8000000000000, 1.0]
+        - [0x000fffffffffffff, 1.0]
+        - [0x0000000000000001, 1.0]
+        - [0x800fffffffffffff, 1.0]
+        - [0x8000000000000001, 1.0]
+        - [0x7fefffffffffffff, 1.0]
+        - [0x0010000000000000, 1.0]
+        - [0xffefffffffffffff, 1.0]
+        - [0x8010000000000000, 1.0]
+        - type: bitrange
+          min: 0x8000000000000001
+          max: 0x800fffffffffffff
+        - type: bitrange
+          min: 0x0000000000000001
+          max: 0x000fffffffffffff
+        - type: bitrange
+          min: 0x8010000000000000
+          max: 0xffefffffffffffff
+        - type: bitrange
+          min: 0x0010000000000000
+          max: 0x7fefffffffffffff
+histogram:
+  - [FMADD_S, 1.0]
+  - [FMSUB_S, 1.0]
+  - [FNMSUB_S, 1.0]
+  - [FNMADD_S, 1.0]
+  - [FADD_S, 1.0]
+  - [FSUB_S, 1.0]
+  - [FMUL_S, 1.0]
+  - [FDIV_S, 1.0]
+  - [FSQRT_S, 1.0]
+  - [FSGNJ_S, 1.0]
+  - [FSGNJN_S, 1.0]
+  - [FSGNJX_S, 1.0]
+  - [FMIN_S, 1.0]
+  - [FMAX_S, 1.0]
+  - [FCVT_W_S, 1.0]
+  - [FCVT_WU_S, 1.0]
+  - [FMV_X_W, 1.0]
+  - [FEQ_S, 1.0]
+  - [FLT_S, 1.0]
+  - [FLE_S, 1.0]
+  - [FCLASS_S, 1.0]
+  - [FCVT_S_W, 1.0]
+  - [FCVT_S_WU, 1.0]
+  - [FMV_W_X, 1.0]
+  - [FCVT_L_S, 1.0]
+  - [FCVT_LU_S, 1.0]
+  - [FCVT_S_L, 1.0]
+  - [FCVT_S_LU, 1.0]
+  - [FLW, 1.0]
+  - [FSW, 1.0]
+  - [FMADD_D, 1.0]
+  - [FMSUB_D, 1.0]
+  - [FNMSUB_D, 1.0]
+  - [FNMADD_D, 1.0]
+  - [FADD_D, 1.0]
+  - [FSUB_D, 1.0]
+  - [FMUL_D, 1.0]
+  - [FDIV_D, 1.0]
+  - [FSQRT_D, 1.0]
+  - [FSGNJ_D, 1.0]
+  - [FSGNJN_D, 1.0]
+  - [FSGNJX_D, 1.0]
+  - [FMIN_D, 1.0]
+  - [FMAX_D, 1.0]
+  - [FCVT_W_D, 1.0]
+  - [FCVT_WU_D, 1.0]
+  - [FCVT_D_W, 1.0]
+  - [FCVT_D_WU, 1.0]
+  - [FMV_X_D, 1.0]
+  - [FEQ_D, 1.0]
+  - [FLT_D, 1.0]
+  - [FLE_D, 1.0]
+  - [FCLASS_D, 1.0]
+  - [FMV_D_X, 1.0]
+  - [FCVT_L_D, 1.0]
+  - [FCVT_LU_D, 1.0]
+  - [FCVT_D_L, 1.0]
+  - [FCVT_D_LU, 1.0]
+  - [FCVT_S_D, 1.0]
+  - [FCVT_D_S, 1.0]
+  - [FLD, 1.0]
+  - [FSD, 1.0]
+
+# CHECK-NOT: error

--- a/llvm/test/tools/llvm-snippy/floating-point/float-nan-propagation.yaml
+++ b/llvm/test/tools/llvm-snippy/floating-point/float-nan-propagation.yaml
@@ -1,0 +1,25 @@
+# RUN: llvm-snippy %s --model-plugin None | FileCheck %s
+
+include:
+  - ../Inputs/sections.yaml
+options:
+  march: riscv64-unknown-elf
+  mcpu: generic-rv64
+  mattr: "+d"
+  num-instrs: 1000
+  dump-mf: true
+fpu-config:
+  overwrite:
+    range:
+      min: 1
+      max: 1
+      rounding-mode: rne
+histogram:
+  - [FMUL_D, 1.0]
+
+# regex to match the following code:
+# REG = FMUL_D ...
+# ... ADDI ...
+# ... SLLI ...
+# REG = FMV_D_X
+# CHECK: [[REG:\$f[[:digit:]]+_d]] = FMUL_D {{.*([[:space:]]+).*ADDI.*([[:space:]]+).*SLLI.*([[:space:]]+)}} [[REG]] = FMV_D_X

--- a/llvm/tools/llvm-snippy/include/snippy/Config/RegisterHistogram.h
+++ b/llvm/tools/llvm-snippy/include/snippy/Config/RegisterHistogram.h
@@ -14,7 +14,6 @@
 #include "llvm/ADT/APInt.h"
 #include "llvm/ADT/SmallVector.h"
 
-#include <optional>
 #include <string>
 #include <variant>
 #include <vector>
@@ -32,6 +31,7 @@ struct RegisterValues {
 };
 
 struct RegisterClassHistogram {
+  bool isEmpty() const { return TheValuegram.empty(); }
   std::string RegType;
   Valuegram TheValuegram;
 };

--- a/llvm/tools/llvm-snippy/include/snippy/Config/SerDesUtils.h
+++ b/llvm/tools/llvm-snippy/include/snippy/Config/SerDesUtils.h
@@ -9,8 +9,9 @@
 #ifndef LLVM_TOOLS_SNIPPY_LIB_SERDES_UTILS_H
 #define LLVM_TOOLS_SNIPPY_LIB_SERDES_UTILS_H
 
-#include "ImmediateHistogram.h"
-#include "RegisterHistogram.h"
+#include "snippy/Config/ImmediateHistogram.h"
+#include "snippy/Config/RegisterHistogram.h"
+#include "snippy/Support/YAMLUtils.h"
 
 #include "llvm/ADT/APFloat.h"
 

--- a/llvm/tools/llvm-snippy/include/snippy/Support/APIntSampler.h
+++ b/llvm/tools/llvm-snippy/include/snippy/Support/APIntSampler.h
@@ -1,0 +1,119 @@
+//===-- APIntSampler.h ------------------------------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#pragma once
+
+#include "llvm/ADT/APInt.h"
+#include "llvm/Support/Error.h"
+
+#include <memory>
+#include <type_traits>
+#include <vector>
+
+namespace llvm {
+namespace snippy {
+
+// (NOTE): Ideally this would not depend on global context and
+// snippy::RandEngine, but alas, it's too deeply ingrained in the current code
+// and ripping it out would be a huge refactor. At some point we really do need
+// to create a separate random engine entity, which is not global.
+class IAPIntSampler {
+public:
+  virtual Expected<APInt> sample() = 0;
+  virtual ~IAPIntSampler() = default;
+};
+
+class ConstantAPIntSampler : public IAPIntSampler {
+public:
+  explicit ConstantAPIntSampler(llvm::APInt Val) : TheValue(std::move(Val)) {}
+  Expected<APInt> sample() override { return TheValue; }
+
+private:
+  APInt TheValue;
+};
+
+class APIntRangeSampler : public IAPIntSampler {
+protected:
+  using LargestUnsignedNativeType =
+      decltype(std::declval<APInt>().getZExtValue());
+  using LargestSignedNativeType =
+      decltype(std::declval<APInt>().getSExtValue());
+
+  auto getBitWidth() const { return TheMin.getBitWidth(); }
+
+public:
+  explicit APIntRangeSampler(APInt Min, APInt Max, bool IsSigned = false);
+  static Expected<APIntRangeSampler> create(APInt Min, APInt Max,
+                                            bool IsSigned = false);
+
+  Expected<APInt> sample() override;
+
+private:
+  APInt TheMin;
+  APInt TheMax;
+  bool TheIsSigned;
+};
+
+class BitPatternAPIntSamler : public IAPIntSampler {
+public:
+  BitPatternAPIntSamler(uint32_t NumBits) : TheNumBits{NumBits} {}
+  auto getNumBits() const noexcept { return TheNumBits; }
+  Expected<APInt> sample() override { return generate(getNumBits()); }
+  static APInt generate(uint32_t NumBits);
+
+private:
+  uint32_t TheNumBits;
+};
+
+class UniformAPIntSamler : public IAPIntSampler {
+public:
+  UniformAPIntSamler(uint32_t NumBits) : TheNumBits{NumBits} {}
+  auto getNumBits() const noexcept { return TheNumBits; }
+  Expected<APInt> sample() override { return generate(getNumBits()); }
+  static APInt generate(uint32_t NumBits);
+
+private:
+  uint32_t TheNumBits;
+};
+
+class WeightedAPIntSamplerSetBuilder {
+  struct WeightedSamplerT {
+    WeightedSamplerT(std::unique_ptr<IAPIntSampler> SamplerParam,
+                     double WeightParam)
+        : Sampler(std::move(SamplerParam)), Weight(WeightParam) {}
+    std::unique_ptr<IAPIntSampler> Sampler;
+    double Weight;
+  };
+
+public:
+  WeightedAPIntSamplerSetBuilder() = default;
+
+  template <typename SamplerT, typename = std::enable_if_t<
+                                   std::is_base_of_v<IAPIntSampler, SamplerT>>>
+  void addOwned(SamplerT Sampler, double Weight) {
+    WeightedSamplers.emplace_back(
+        /*Sampler=*/std::make_unique<SamplerT>(std::move(Sampler)),
+        /*Weight=*/Weight);
+  }
+
+  void addOwned(std::unique_ptr<IAPIntSampler> Sampler, double Weight) {
+    WeightedSamplers.emplace_back(
+        /*Sampler=*/std::move(Sampler),
+        /*Weight=*/Weight);
+  }
+
+  bool isEmpty() const { return WeightedSamplers.empty(); }
+
+  std::unique_ptr<IAPIntSampler> build();
+
+private:
+  std::vector<WeightedSamplerT> WeightedSamplers;
+};
+
+} // namespace snippy
+} // namespace llvm

--- a/llvm/tools/llvm-snippy/include/snippy/Support/Error.h
+++ b/llvm/tools/llvm-snippy/include/snippy/Support/Error.h
@@ -34,5 +34,9 @@ public:
                 RegInfo.getRegClassName(&RegClass) + ": " + Msg) {}
 };
 
+inline void burrowError(Error E) {
+  handleAllErrors(std::move(E), [](const ErrorInfoBase &EI) {});
+}
+
 } // namespace snippy
 } // namespace llvm

--- a/llvm/tools/llvm-snippy/include/snippy/Support/RandUtil.h
+++ b/llvm/tools/llvm-snippy/include/snippy/Support/RandUtil.h
@@ -198,6 +198,8 @@ public:
     return genInInterval<T>(First, Last - 1);
   }
 
+  static bool genBool() { return genInRange(0, 1); }
+
   template <typename T> static T genInRange(T Last) {
     return genInRange<T>(0, Last);
   }

--- a/llvm/tools/llvm-snippy/include/snippy/Support/YAMLUtils.h
+++ b/llvm/tools/llvm-snippy/include/snippy/Support/YAMLUtils.h
@@ -61,7 +61,7 @@
   struct _type {                                                               \
     _type() : value() {}                                                       \
     _type(const _mapped &w) : value(w) {}                                      \
-    operator const _mapped &() const { return value; }                         \
+    operator const _mapped &() const & { return value; }                       \
     _mapped value;                                                             \
   }
 

--- a/llvm/tools/llvm-snippy/lib/Config/FPUSettings.cpp
+++ b/llvm/tools/llvm-snippy/lib/Config/FPUSettings.cpp
@@ -7,41 +7,502 @@
 //===----------------------------------------------------------------------===//
 
 #include "snippy/Config/FPUSettings.h"
+#include "snippy/Support/RandUtil.h"
 
+#include "llvm/ADT/APFloat.h"
+#include "llvm/ADT/TypeSwitch.h"
+#include "llvm/ADT/identity.h"
 #include "llvm/Support/YAMLTraits.h"
 
 namespace llvm {
+
+namespace {
+
+Error checkOverflowIntegralConversionError(const APInt &Val,
+                                           APFloat::opStatus Status,
+                                           bool IsSigned) {
+  if (Status != APFloat::opStatus::opOK &&
+      Status != APFloat::opStatus::opInexact) {
+    assert(Status & APFloat::opStatus::opOverflow);
+    SmallString<16> StrVal;
+    Val.toString(StrVal, /*Radix=*/16, /*Signed=*/IsSigned,
+                 /*formatAsCLiteral=*/true, /*UpperCase=*/false);
+    return createStringError(
+        std::make_error_code(std::errc::result_out_of_range),
+        Twine("Conversion from integer value '")
+            .concat(StrVal)
+            .concat("' would result in a floating-point overflow exception"));
+  }
+
+  return Error::success();
+}
+
+Error checkIntegralRangeOverflow(const snippy::FloatOverwriteRange &Range,
+                                 RoundingMode RM,
+                                 const fltSemantics &Semantics) {
+  // (NOTE): Check that overflow does not occur. In case it does that means
+  // that the range of values is too wide for the chosen floating-point type.
+  // This should be possible only for half-precision types. Inexact operation
+  // is allowed, since large integral values will not be exactly represented
+  // as floats.
+  //
+  // From IEEE-754-2008 5.4.1 Arithmetic operations:
+  // formatOf-convertFromInt(int)
+  //
+  // Integral values are converted exactly from integer formats to
+  // floating-point formats whenever the value is representable in both
+  // formats.
+  //
+  // If the converted value is not exactly representable in the destination
+  // format, the result is determined according to the applicable
+  // rounding-direction attribute, and an inexact or floating-point overflow
+  // exception arises as specified in Clause 7.
+  //
+  // 7.4 Overflow
+  //
+  // In addition, under default exception handling for overflow, the
+  // overflow flag shall be raised and the inexact
+  // exception shall be signaled.
+
+  auto CheckValue = [&](auto Val) -> Error {
+    auto FPValue = APFloat{Semantics};
+    constexpr auto IsSigned = std::is_signed_v<decltype(Val)>;
+    auto SampledAPInt =
+        APInt{CHAR_BIT * sizeof(decltype(Val)), static_cast<uint64_t>(Val),
+              /*IsSigned=*/IsSigned};
+    auto Status =
+        FPValue.convertFromAPInt(SampledAPInt, /*IsSigned=*/IsSigned, RM);
+    return checkOverflowIntegralConversionError(SampledAPInt, Status, IsSigned);
+  };
+
+  if (auto Err = CheckValue(Range.Min))
+    return Err;
+
+  if (auto Err = CheckValue(Range.Max))
+    return Err;
+
+  // If the overflow does not occur on the ends of the value range,
+  // then for internal values it shall not occur.
+  return Error::success();
+}
+
+Expected<const snippy::FloatOverwriteValues *>
+getSettingsForSemantics(const snippy::FloatOverwriteSettings &Settings,
+                        const fltSemantics &Semantics) {
+  if (auto &Cfg = Settings.HalfValues; &Semantics == &APFloat::IEEEhalf())
+    return Cfg ? &Cfg.value() : nullptr;
+  if (auto &Cfg = Settings.SingleValues; &Semantics == &APFloat::IEEEsingle())
+    return Cfg ? &Cfg.value() : nullptr;
+  if (auto &Cfg = Settings.DoubleValues; &Semantics == &APFloat::IEEEdouble())
+    return Cfg ? &Cfg.value() : nullptr;
+  return createStringError(
+      std::make_error_code(std::errc::invalid_argument),
+      Twine("Requested floating-point semantics is not supported"));
+}
+
+Error createTooLargeForWidthError(uint32_t ValueWidth, Twine ValStr) {
+  return createStringError(std::make_error_code(std::errc::result_out_of_range),
+                           Twine("'")
+                               .concat(ValStr)
+                               .concat("' is too wide to fit in ")
+                               .concat(Twine(ValueWidth))
+                               .concat(" bits"));
+}
+
+} // namespace
 
 using snippy::FPUSettings;
 void yaml::MappingTraits<FPUSettings>::mapping(yaml::IO &IO, FPUSettings &Cfg) {
   IO.mapOptional("overwrite", Cfg.Overwrite);
 }
 
+using snippy::FloatOverwriteValues;
+void yaml::MappingTraits<FloatOverwriteValues>::mapping(
+    yaml::IO &IO, FloatOverwriteValues &Cfg) {
+  IO.mapOptional("valuegram", Cfg.TheValuegram);
+}
+
+std::string
+yaml::MappingTraits<FloatOverwriteValues>::validate(yaml::IO &IO,
+                                                    FloatOverwriteValues &Cfg) {
+  using snippy::RegisterClassHistogram;
+  auto ContainsNegativeValues =
+      any_of(Cfg.TheValuegram, [](const snippy::ValuegramEntry &Entry) {
+        if (auto *BitValue =
+                dyn_cast<snippy::ValuegramBitValueEntry>(&Entry.get()))
+          return BitValue->isSigned();
+        return false;
+      });
+
+  if (ContainsNegativeValues)
+    return "Negative values are not allowed in a valuegram";
+
+  return "";
+}
+
 using snippy::FloatOverwriteSettings;
 void yaml::MappingTraits<FloatOverwriteSettings>::mapping(
     yaml::IO &IO, FloatOverwriteSettings &Cfg) {
-  IO.mapRequired("range", Cfg.Range);
   IO.mapOptional("mode", Cfg.Mode);
+  IO.mapOptional("range", Cfg.IntegralRange);
+  IO.mapOptional("ieee-half", Cfg.HalfValues);
+  IO.mapOptional("ieee-single", Cfg.SingleValues);
+  IO.mapOptional("ieee-double", Cfg.DoubleValues);
+}
+
+namespace snippy {
+namespace {
+
+template <typename T>
+class IntRangeAsFloatSampler final : public IAPIntSampler {
+public:
+  template <typename C, typename D>
+  IntRangeAsFloatSampler(C Min, D Max, RoundingMode Mode,
+                         const fltSemantics &Semantics)
+      : TheMin{Min}, TheMax{Max}, RM{Mode}, TheSemantics{Semantics} {
+    assert(Min <= Max);
+  }
+
+  template <typename C, typename D>
+  static Expected<IntRangeAsFloatSampler>
+  create(C Min, D Max, RoundingMode Mode, const fltSemantics &Semantics) {
+    if (Min > Max)
+      return createStringError(
+          std::make_error_code(std::errc::invalid_argument),
+          Twine("'max' should be greater or equal to 'min'"));
+
+    return IntRangeAsFloatSampler(Min, Max, Mode, Semantics);
+  }
+
+  Expected<APInt> sample() override {
+    auto FPValue = APFloat{TheSemantics};
+    auto SampledIntValue = RandEngine::genInInterval(TheMin, TheMax);
+    constexpr auto IsSigned = std::is_signed_v<T>;
+    auto SampledAPInt =
+        APInt{CHAR_BIT * sizeof(T), static_cast<uint64_t>(SampledIntValue),
+              /*IsSigned=*/IsSigned};
+
+    auto Status =
+        FPValue.convertFromAPInt(SampledAPInt, /*IsSigned=*/IsSigned, RM);
+
+    if (auto Err = checkOverflowIntegralConversionError(SampledAPInt, Status,
+                                                        IsSigned))
+      return Err;
+
+    return FPValue.bitcastToAPInt();
+  }
+
+private:
+  T TheMin;
+  T TheMax;
+  RoundingMode RM;
+  const fltSemantics &TheSemantics;
+};
+
+template <typename T, typename = std::enable_if_t<std::is_integral_v<T>>>
+Expected<APInt> createAPIntOfWidth(uint32_t BitWidth, T Val) {
+  static constexpr auto IsSigned = std::is_signed_v<T>;
+  static_assert(!IsSigned);
+  auto LeadingZeros = countl_zero(Val);
+  auto NumBits = sizeof(decltype(Val)) * CHAR_BIT;
+  auto NumActiveBits = NumBits - LeadingZeros;
+  if (NumActiveBits > BitWidth)
+    return createTooLargeForWidthError(
+        BitWidth, Twine("0x").concat(utohexstr(Val, /*LowerCase=*/true)));
+  return APInt{BitWidth, static_cast<uint64_t>(Val),
+               /*isSigned=*/IsSigned};
+}
+
+} // namespace
+
+template <typename... Ts, typename = std::enable_if_t<std::conjunction_v<
+                              std::is_same<std::decay_t<Ts>, APInt>...>>>
+static std::optional<APInt> checkAPIntsInRange(uint32_t SemanticsSize,
+                                               Ts &&...Vals) {
+  auto CheckAPIntsImpl = [&](auto &&Self, const APInt &FrontVal,
+                             const auto &...TailVals) -> std::optional<APInt> {
+    auto CheckAPInt = [&](const APInt &Val) -> std::optional<APInt> {
+      return Val.getActiveBits() > SemanticsSize ? std::optional{Val}
+                                                 : std::nullopt;
+    };
+
+    auto FrontChecked = CheckAPInt(FrontVal);
+    if constexpr (sizeof...(TailVals) >= 1)
+      return FrontChecked ? FrontChecked : Self(Self, TailVals...);
+    else
+      return FrontChecked;
+  };
+
+  return CheckAPIntsImpl(CheckAPIntsImpl, Vals...);
+}
+
+static std::optional<APInt>
+checkOutOfRangeValuegram(uint32_t SemanticsSize, const IValuegramEntry &Entry) {
+  auto CheckAPInts = [SemanticsSize](auto &&...Vals) {
+    return checkAPIntsInRange(SemanticsSize, Vals...);
+  };
+
+  return TypeSwitch<const IValuegramEntry *, std::optional<APInt>>(&Entry)
+      .Case([&](const ValuegramBitValueEntry *BitValueEntry) {
+        assert(BitValueEntry);
+        return CheckAPInts(BitValueEntry->ValWithSign.Value);
+      })
+      .Case([&](const ValuegramBitRangeEntry *BitRangeEntry) {
+        assert(BitRangeEntry);
+        return CheckAPInts(BitRangeEntry->Min, BitRangeEntry->Max);
+      })
+      .Default([](auto &&) { return std::nullopt; });
+}
+
+static std::string
+validateValuegramForSemantics(const Valuegram &VG,
+                              const fltSemantics &Semantics) {
+  auto SemanticsSize = APFloat::getSizeInBits(Semantics);
+
+  // NOTE: During validation some entries might be null. That means that their
+  // mapping was invalid and got diagnosed earlier on. We can safely skip them
+  // and validate valid ones.
+  auto NonNullEntries =
+      make_filter_range(VG, [](const ValuegramEntry &Entry) -> bool {
+        return Entry.getOrNull();
+      });
+
+  auto CheckedRange =
+      map_range(NonNullEntries, [&](const ValuegramEntry &Entry) {
+        return checkOutOfRangeValuegram(SemanticsSize, Entry.get());
+      });
+
+  if (auto EntryIt = find_if(
+          CheckedRange,
+          [](auto &&OptionalVal) -> bool { return OptionalVal.has_value(); });
+      EntryIt != CheckedRange.end()) {
+    auto OutOfRangeValue = *EntryIt;
+    SmallString<sizeof(uint64_t) * CHAR_BIT / 4> ValStr;
+    OutOfRangeValue->toString(ValStr, /*Radix=*/16, /*Signed=*/false,
+                              /*formatAsCLiteral=*/true,
+                              /*UpperCase=*/false);
+    return toString(createTooLargeForWidthError(SemanticsSize, ValStr));
+  }
+
+  return "";
+}
+
+static Expected<std::unique_ptr<IAPIntSampler>>
+createSamplerForEntry(const ValuegramEntry &Entry, uint32_t BitWidth) {
+  return TypeSwitch<const IValuegramEntry *,
+                    Expected<std::unique_ptr<IAPIntSampler>>>(&Entry.get())
+      .Case([&](const ValuegramBitpatternEntry *) {
+        return std::make_unique<BitPatternAPIntSamler>(BitWidth);
+      })
+      .Case([&](const ValuegramUniformEntry *) {
+        return std::make_unique<UniformAPIntSamler>(BitWidth);
+      })
+      .Case([&](const ValuegramBitValueEntry *BitValueEntry)
+                -> Expected<std::unique_ptr<IAPIntSampler>> {
+        const auto &Val = BitValueEntry->ValWithSign.Value;
+        if (Val.getActiveBits() > BitWidth) {
+          SmallString<sizeof(uint64_t) * CHAR_BIT / 4> ValStr;
+          Val.toString(ValStr, /*Radix=*/16, /*Signed=*/false,
+                       /*formatAsCLiteral=*/true, /*UpperCase=*/false);
+          return createTooLargeForWidthError(BitWidth, ValStr);
+        }
+        return std::make_unique<ConstantAPIntSampler>(
+            Val.zextOrTrunc(BitWidth));
+      })
+      .Case([&](const ValuegramBitRangeEntry *BitRangeEntry)
+                -> Expected<std::unique_ptr<IAPIntSampler>> {
+        assert(BitRangeEntry);
+        auto SamplerOrErr =
+            APIntRangeSampler::create(BitRangeEntry->Min, BitRangeEntry->Max,
+                                      /*IsSigned=*/false);
+        if (Error E = SamplerOrErr.takeError())
+          return E;
+        return std::make_unique<APIntRangeSampler>(std::move(*SamplerOrErr));
+      })
+      .Default([](auto &&) {
+        return createStringError(inconvertibleErrorCode(),
+                                 Twine("Unhandled valuegram entry type"));
+      });
+}
+
+} // namespace snippy
+
+std::string yaml::MappingTraits<FloatOverwriteSettings>::validate(
+    yaml::IO &IO, FloatOverwriteSettings &Cfg) {
+  auto RM = RoundingMode::NearestTiesToEven;
+
+  auto AvailableSemantics = std::array<const fltSemantics *, 3>{
+      &APFloat::IEEEhalf(), &APFloat::IEEEsingle(), &APFloat::IEEEdouble()};
+
+  auto GetSettingsForSemantics = [&](const fltSemantics *Semantics) {
+    assert(Semantics);
+    return cantFail(getSettingsForSemantics(Cfg, *Semantics));
+  };
+
+  if (Cfg.IntegralRange) {
+    auto PresentSemantics = make_filter_range(
+        AvailableSemantics, [&](const fltSemantics *Semantics) -> bool {
+          return GetSettingsForSemantics(Semantics);
+        });
+
+    auto CheckedIntegralOverflowRange =
+        map_range(PresentSemantics, [&](const fltSemantics *Semantics) {
+          return checkIntegralRangeOverflow(*Cfg.IntegralRange, RM, *Semantics);
+        });
+
+    if (auto ErrIt = find_if_not(CheckedIntegralOverflowRange,
+                                 [](Error Err) {
+                                   auto Success = Err.success();
+                                   snippy::burrowError(std::move(Err));
+                                   return Success;
+                                 });
+        ErrIt != CheckedIntegralOverflowRange.end())
+      return toString(*ErrIt);
+  }
+
+  {
+    auto SettingForSemantics =
+        map_range(AvailableSemantics, GetSettingsForSemantics);
+
+    auto SemanticsWithSettings = zip(AvailableSemantics, SettingForSemantics);
+    for (auto &&[Semantics, SettingsPtr] : SemanticsWithSettings) {
+      if (!SettingsPtr)
+        continue;
+      if (auto ErrMsg = snippy::validateValuegramForSemantics(
+              SettingsPtr->TheValuegram, *Semantics);
+          !ErrMsg.empty())
+        return ErrMsg;
+    }
+  }
+
+  return "";
+}
+
+namespace {
+
+struct NormalizedRoundingMode final {
+  snippy::FPURoundingMode RMWrapper;
+  NormalizedRoundingMode(yaml::IO &Io) {}
+  NormalizedRoundingMode(yaml::IO &Io, const RoundingMode &Denorm)
+      : RMWrapper{Denorm} {}
+  RoundingMode denormalize(yaml::IO &Io) { return RMWrapper.value; }
+};
+
+} // namespace
+
+void yaml::ScalarEnumerationTraits<snippy::FPURoundingMode>::enumeration(
+    IO &Io, snippy::FPURoundingMode &Value) {
+  auto EnumCase = [&](const char *Name, RoundingMode RM) {
+    Io.enumCase(Value.value, Name, RM);
+  };
+
+  EnumCase("nearest-ties-to-even", RoundingMode::NearestTiesToEven);
+  EnumCase("toward-zero", RoundingMode::TowardZero);
+  EnumCase("toward-negative", RoundingMode::TowardNegative);
+  EnumCase("toward-positive", RoundingMode::TowardPositive);
+  EnumCase("nearest-ties-to-away", RoundingMode::NearestTiesToAway);
+
+  // NOTE: When inputting data we allow shorthands like in risc-v isa manual
+  // for conciseness.
+  if (!Io.outputting()) {
+    EnumCase("rne", RoundingMode::NearestTiesToEven);
+    EnumCase("rtz", RoundingMode::TowardZero);
+    EnumCase("rdn", RoundingMode::TowardNegative);
+    EnumCase("rup", RoundingMode::TowardPositive);
+    EnumCase("rmm", RoundingMode::NearestTiesToAway);
+  }
 }
 
 using snippy::FloatOverwriteRange;
 void yaml::MappingTraits<FloatOverwriteRange>::mapping(
-    yaml::IO &IO, FloatOverwriteRange &Cfg) {
-  IO.mapRequired("max", Cfg.Max);
-  IO.mapRequired("min", Cfg.Min);
+    yaml::IO &Io, FloatOverwriteRange &Cfg) {
+  yaml::MappingNormalization<NormalizedRoundingMode, RoundingMode>
+      RoundingModeNorm(Io, Cfg.RM);
+  Io.mapRequired("min", Cfg.Min);
+  Io.mapRequired("max", Cfg.Max);
+  Io.mapOptional("rounding-mode", RoundingModeNorm->RMWrapper);
+  Io.mapOptional("weight", Cfg.Weight, 1.0);
 }
 
 std::string
 yaml::MappingTraits<FloatOverwriteRange>::validate(yaml::IO &IO,
                                                    FloatOverwriteRange &Cfg) {
   if (Cfg.Min > Cfg.Max)
-    return "Max should be greater or equal than min.";
+    return "'max' should be greater or equal to 'min'";
   return "";
 }
+
 using snippy::FloatOverwriteMode;
 void yaml::ScalarEnumerationTraits<FloatOverwriteMode>::enumeration(
     yaml::IO &IO, FloatOverwriteMode &M) {
   IO.enumCase(M, "if-all-operands", FloatOverwriteMode::IF_ALL_OPERANDS);
   IO.enumCase(M, "if-any-operand", FloatOverwriteMode::IF_ANY_OPERAND);
+  IO.enumCase(M, "disabled", FloatOverwriteMode::DISABLED);
 }
+
+namespace snippy {
+
+Expected<std::unique_ptr<IAPIntSampler>>
+createFloatOverwriteValueSampler(const FloatOverwriteSettings &Settings,
+                                 const fltSemantics &Semantics) {
+  snippy::WeightedAPIntSamplerSetBuilder Builder;
+  auto BitWidth = APFloat::semanticsSizeInBits(Semantics);
+
+  Expected<const FloatOverwriteValues *> CfgOrErr =
+      getSettingsForSemantics(Settings, Semantics);
+
+  if (auto Err = CfgOrErr.takeError())
+    return Err;
+
+  // (NOTE): Fallback case. The most reasonable choice for default
+  // distribution is uniform.
+  auto BuildWithFallback = [&]() {
+    if (Builder.isEmpty())
+      Builder.addOwned(std::make_unique<UniformAPIntSamler>(BitWidth), 1.0);
+    return Builder.build();
+  };
+
+  if (const auto &IntegralRange = Settings.IntegralRange) {
+    auto SamplerOrErr =
+        IntRangeAsFloatSampler<FloatOverwriteRange::ValueType>::create(
+            IntegralRange->Min, IntegralRange->Max, IntegralRange->RM,
+            Semantics);
+
+    if (auto E = SamplerOrErr.takeError())
+      return E;
+
+    Builder.addOwned(std::move(*SamplerOrErr), IntegralRange->Weight);
+  }
+
+  auto *Cfg = *CfgOrErr;
+  if (!Cfg)
+    return BuildWithFallback();
+
+  for (const auto &Entry : Cfg->TheValuegram) {
+    auto SamplerOrErr = createSamplerForEntry(Entry, BitWidth);
+    if (Error E = SamplerOrErr.takeError())
+      return E;
+    Builder.addOwned(std::move(*SamplerOrErr), Entry.getWeight());
+  }
+
+  return BuildWithFallback();
+}
+
+Expected<IAPIntSampler &>
+FloatSemanticsSamplerHolder::getSamplerFor(const fltSemantics &Semantics) {
+  auto FoundIt = FloatValueSamplerForSemantics.find(&Semantics);
+
+  if (FoundIt != FloatValueSamplerForSemantics.end())
+    return *FoundIt->second;
+
+  auto SamplerOrErr =
+      createFloatOverwriteValueSampler(OverwriteSettings, Semantics);
+  auto [InsertedIt, _] =
+      FloatValueSamplerForSemantics.emplace(&Semantics, nullptr);
+  if (auto Err = std::move(SamplerOrErr).moveInto(InsertedIt->second))
+    return Err;
+  return *InsertedIt->second;
+}
+
+} // namespace snippy
 } // namespace llvm

--- a/llvm/tools/llvm-snippy/lib/Support/APIntSampler.cpp
+++ b/llvm/tools/llvm-snippy/lib/Support/APIntSampler.cpp
@@ -1,0 +1,126 @@
+//===-- APIntSampler.cpp ----------------------------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "snippy/Support/APIntSampler.h"
+#include "snippy/Support/RandUtil.h"
+
+#include "llvm/ADT/STLExtras.h"
+
+namespace llvm::snippy {
+
+Expected<APInt> APIntRangeSampler::sample() {
+  // (FIXME): Rip out global engine.
+
+  if (!TheIsSigned) {
+    auto Dist = UniformIntDistribution<LargestUnsignedNativeType>(
+        TheMin.getZExtValue(), TheMax.getZExtValue());
+    auto Val = Dist(RandEngine::engine());
+    return llvm::APInt{getBitWidth(), Val, /*isSigned=*/false};
+  }
+
+  auto Dist = UniformIntDistribution<LargestSignedNativeType>(
+      TheMin.getSExtValue(), TheMax.getSExtValue());
+  auto Val = Dist(RandEngine::engine());
+  // (NOTE): APInt constructor accepts a uint64_t and reinterperts it as a
+  // signed value.
+  return llvm::APInt{getBitWidth(), static_cast<LargestUnsignedNativeType>(Val),
+                     /*isSigned=*/true};
+}
+
+APInt BitPatternAPIntSamler::generate(uint32_t NumBits) {
+  auto Result = APInt::getZero(NumBits);
+  auto Stride = RandEngine::genInRange<unsigned>(1, NumBits);
+  auto Idx = RandEngine::genInInterval<unsigned>(0, Stride);
+  while (Idx < NumBits) {
+    Result.insertBits(1, Idx, 1);
+    Idx += Stride;
+  }
+  if (RandEngine::genBool())
+    return ~Result;
+  return Result;
+}
+
+APInt UniformAPIntSamler::generate(uint32_t NumBits) {
+  return RandEngine::genAPInt(NumBits);
+}
+
+namespace {
+
+struct WeightedAPIntSamplerSet final : public IAPIntSampler {
+  std::discrete_distribution<std::size_t> Dist;
+  std::vector<std::unique_ptr<IAPIntSampler>> OwnedSamplers;
+
+  template <typename T>
+  WeightedAPIntSamplerSet(T &&WeightedSamplers)
+      : Dist([&]() {
+          auto WeightRange = llvm::map_range(
+              WeightedSamplers, [](auto &&Val) { return Val.Weight; });
+          return decltype(Dist)(WeightRange.begin(), WeightRange.end());
+        }()) {
+    copy(map_range(WeightedSamplers,
+                   [](auto &&Val) { return std::move(Val.Sampler); }),
+         std::back_inserter(OwnedSamplers));
+  }
+
+  Expected<APInt> sample() override {
+    auto Idx = Dist(RandEngine::engine());
+    auto &ChosenSampler = *OwnedSamplers[Idx];
+    return ChosenSampler.sample();
+  }
+};
+
+} // namespace
+
+std::unique_ptr<IAPIntSampler> WeightedAPIntSamplerSetBuilder::build() {
+  return std::make_unique<WeightedAPIntSamplerSet>(WeightedSamplers);
+}
+
+APIntRangeSampler::APIntRangeSampler(APInt Min, APInt Max, bool IsSigned)
+    : TheMin(std::move(Min)), TheMax(std::move(Max)), TheIsSigned(IsSigned) {
+  assert((!IsSigned && TheMin.ule(TheMax)) || TheMin.sle(TheMax));
+  assert(TheMin.getBitWidth() == TheMax.getBitWidth());
+  // (NOTE): Implementing this for larger values would require
+  // a thorough rewrite of UniformIntDistribution to support APInt natively.
+  assert(TheMin.getBitWidth() <= CHAR_BIT * sizeof(LargestUnsignedNativeType) &&
+         "APIntRangeSampler is not implemented for values wider than 64 bits");
+}
+
+Expected<APIntRangeSampler> APIntRangeSampler::create(APInt Min, APInt Max,
+                                                      bool IsSigned) {
+  auto CommonBitLength = std::max(Min.getBitWidth(), Max.getBitWidth());
+
+  if (!IsSigned) {
+    Min = Min.zext(CommonBitLength);
+    Max = Max.zext(CommonBitLength);
+
+    if (Min.ugt(Max))
+      return createStringError(
+          std::make_error_code(std::errc::invalid_argument),
+          Twine("Min should be no larger than Max"));
+  } else {
+    Min = Min.sext(CommonBitLength);
+    Max = Max.sext(CommonBitLength);
+
+    if (Min.sgt(Max))
+      return createStringError(
+          std::make_error_code(std::errc::invalid_argument),
+          Twine("Min should be no larger than Max"));
+  }
+
+  if (auto MaxBitLength = CHAR_BIT * sizeof(LargestUnsignedNativeType);
+      Min.getBitWidth() > MaxBitLength)
+    return createStringError(
+        std::make_error_code(std::errc::invalid_argument),
+        Twine("APIntRangeSampler is not implemented for values wider than ")
+            .concat(Twine(MaxBitLength))
+            .concat(" bits"));
+
+  return APIntRangeSampler(Min, Max, IsSigned);
+}
+
+} // namespace llvm::snippy

--- a/llvm/tools/llvm-snippy/lib/Support/CMakeLists.txt
+++ b/llvm/tools/llvm-snippy/lib/Support/CMakeLists.txt
@@ -1,4 +1,5 @@
-add_llvm_library(LLVMSnippySupport
+add_llvm_library(
+  LLVMSnippySupport
   DISABLE_LLVM_LINK_LLVM_DYLIB
   STATIC
   DiagnosticInfo.cpp
@@ -9,4 +10,4 @@ add_llvm_library(LLVMSnippySupport
   RandUtil.cpp
   Utils.cpp
   YAMLUtils.cpp
-)
+  APIntSampler.cpp)

--- a/llvm/tools/llvm-snippy/llvm-snippy.cpp
+++ b/llvm/tools/llvm-snippy/llvm-snippy.cpp
@@ -977,12 +977,7 @@ static void checkFPUSettings(Config &Cfg, LLVMContext &Ctx,
   auto &FPUConfig = *Cfg.FPUConfig;
   if (FPUConfig.Overwrite)
     return;
-  static constexpr int Min = -1000;
-  static constexpr int Max = 1000;
-  snippy::notice(WarningName::NotAWarning, Ctx,
-                 "Float override range was not specified",
-                 "Using range: [" + Twine(Min) + ", " + Twine(Max) + "]");
-  FPUConfig.Overwrite = FloatOverwriteSettings{FloatOverwriteRange{-Min, Max}};
+  FPUConfig.Overwrite = FloatOverwriteSettings{};
 }
 
 // Function to do all the necessary operations on Config after reading it


### PR DESCRIPTION
[snippy]: Detailed float overwrite value configuration 

This patch implements fine-grained control over floating-point
overwrite value selection. A minimal example of configuration:

```yaml
fpu-config:
  overwrite:
    ieee-double:
      valuegram:
        - [0x0fffffffffffff, 1.0]
        - [uniform, 1.0]
        - [bitpattern, 1.0]
        - type: bitpattern
          weight: 1.0 # by default
        - type: bitrange
          min: 0x8000000000000001
          max: 0x800fffffffffffff
          weight: 1.0
    range: # - treated as integers
      min: 1
      max: 3
      # weight: 1.0 - by default
```

- The behaviour of `range` configuration is preserved. min/max values
  are treated as integer values and are semantically converted to the
  appropriate (according to the semantics) floating-point value in RNE rounding mode.

By default overwrite fills the registers with uniformly distributed bits,
as opposed to the previous (rather dubious) integral range [-1000, 1000].

For each of `ieee-double`, `ieee-single` and `ieee-half` the `valuegram`
option is available. The format is the same as for `init-regs-yaml` histograms.

- `type: bitvalue` is the same as in initial register value configuration,
  but negative values are not allowed.

- `type: bitrange` unsigned bits range. This provides a way to sample the value of underlying
  bits of the floating-point register. Depending on the opcode histogram and
  selected extensions these constants may be crafted to provide 'interesting'
  values for operations present in the histogram.

Depending on the usage of the register after it gets overwritten the
appropriate (for the register usage) values are sampled.