### PR TITLE
[snippy][NFC]: Mark snippy::fatal with [[noreturn]]

### DIFF
--- a/llvm/tools/llvm-snippy/include/snippy/Support/DiagnosticInfo.h
+++ b/llvm/tools/llvm-snippy/include/snippy/Support/DiagnosticInfo.h
@@ -86,12 +86,13 @@ void notice(WarningName WN, llvm::LLVMContext &Ctx, const llvm::Twine &Prefix,
 void warn(WarningName WN, llvm::LLVMContext &Ctx, const llvm::Twine &Prefix,
           const llvm::Twine &Desc);
 
-void fatal(llvm::LLVMContext &Ctx, const llvm::Twine &Prefix,
-           const llvm::Twine &Desc);
+[[noreturn]] void fatal(llvm::LLVMContext &Ctx, const llvm::Twine &Prefix,
+                        const llvm::Twine &Desc);
 
-void fatal(llvm::LLVMContext &Ctx, const llvm::Twine &Prefix, Error E);
+[[noreturn]] void fatal(llvm::LLVMContext &Ctx, const llvm::Twine &Prefix,
+                        Error E);
 
-void fatal(const llvm::Twine &Prefix, const llvm::Twine &Desc);
+[[noreturn]] void fatal(const llvm::Twine &Prefix, const llvm::Twine &Desc);
 
 } // namespace snippy
 

--- a/llvm/tools/llvm-snippy/lib/Support/DiagnosticInfo.cpp
+++ b/llvm/tools/llvm-snippy/lib/Support/DiagnosticInfo.cpp
@@ -73,20 +73,21 @@ void warn(WarningName WN, llvm::LLVMContext &Ctx, const llvm::Twine &Prefix,
   Ctx.diagnose(Diag);
 }
 
-void fatal(llvm::LLVMContext &Ctx, const llvm::Twine &Prefix,
-           const llvm::Twine &Desc) {
+[[noreturn]] void fatal(llvm::LLVMContext &Ctx, const llvm::Twine &Prefix,
+                        const llvm::Twine &Desc) {
   SnippyDiagnosticInfo Diag(Prefix, Desc, llvm::DS_Error,
                             WarningName::NotAWarning);
   Ctx.diagnose(Diag);
 }
 
-void fatal(llvm::LLVMContext &Ctx, const llvm::Twine &Prefix, Error E) {
+[[noreturn]] void fatal(llvm::LLVMContext &Ctx, const llvm::Twine &Prefix,
+                        Error E) {
   SnippyDiagnosticInfo Diag(Prefix, toString(std::move(E)), llvm::DS_Error,
                             WarningName::NotAWarning);
   Ctx.diagnose(Diag);
 }
 
-void fatal(const llvm::Twine &Prefix, const llvm::Twine &Desc) {
+[[noreturn]] void fatal(const llvm::Twine &Prefix, const llvm::Twine &Desc) {
   llvm::LLVMContext Ctx;
   SnippyDiagnosticInfo Diag(Prefix, Desc, llvm::DS_Error,
                             WarningName::NotAWarning);


### PR DESCRIPTION
[snippy][NFC]: Mark snippy::fatal with [[noreturn]]

For DiagnosticSeverity of llvm::DS_Error SnippyDiagnosticInfo
always uses report_fatal_error:

```
if (Severity == llvm::DS_Error)
  llvm::report_fatal_error(StringRef(Description), false);
```

So snippy::fatal will never return, since llvm::report_fatal_error
is also [[noreturn]].