### PR TITLE
[snippy]: Color diagnostic output when possible

### DIFF
--- a/llvm/test/tools/llvm-snippy/memory-scheme/ranges-diag.yaml
+++ b/llvm/test/tools/llvm-snippy/memory-scheme/ranges-diag.yaml
@@ -16,6 +16,6 @@ access-ranges:
       first-offset: 5
       last-offset: 5
 
-# CHECK: Warning: first offset 3 > last offset 1
-# CHECK: Warning: last offset 5 >= stride 5
-# CHECK: Cannot sample memory access for instruction
+# CHECK: warning: Invalid memory access range: 'first-offset' (3) > 'last-offset' (1)
+# CHECK: warning: Invalid memory access range: 'last-offset' (5) >= 'stride' (5)
+# CHECK: error: Cannot sample memory access for instruction

--- a/llvm/test/tools/llvm-snippy/memory-scheme/scheme-generation-option.yaml
+++ b/llvm/test/tools/llvm-snippy/memory-scheme/scheme-generation-option.yaml
@@ -17,4 +17,4 @@
 # TO-STDOUT-NEXT:      - addr: 0x80000000
 # TO-STDOUT-NEXT:      - addr: 0x80000300
 
-# NO-MEM: warning: cannot dump memory accesses as no accesses were generated. File won't be created.
+# NO-MEM: warning: Cannot dump memory accesses: No accesses were generated, file won't be created.

--- a/llvm/tools/llvm-snippy/include/snippy/Support/DiagnosticInfo.h
+++ b/llvm/tools/llvm-snippy/include/snippy/Support/DiagnosticInfo.h
@@ -39,7 +39,8 @@ enum class WarningName {
   TooFarMaxPCDist,
   ModelException,
   UnusedSection,
-  GenPlanVerification
+  GenPlanVerification,
+  SeedNotSpecified,
 };
 
 struct WarningCounters {
@@ -83,8 +84,16 @@ public:
 void notice(WarningName WN, llvm::LLVMContext &Ctx, const llvm::Twine &Prefix,
             const llvm::Twine &Desc);
 
+void notice(const llvm::Twine &Prefix, const llvm::Twine &Desc,
+            WarningName WN = WarningName::NotAWarning);
+
+void notice(llvm::LLVMContext &Ctx, const llvm::Twine &Prefix,
+            const llvm::Twine &Desc, WarningName WN = WarningName::NotAWarning);
+
 void warn(WarningName WN, llvm::LLVMContext &Ctx, const llvm::Twine &Prefix,
           const llvm::Twine &Desc);
+
+void warn(WarningName WN, const llvm::Twine &Prefix, const llvm::Twine &Desc);
 
 [[noreturn]] void fatal(llvm::LLVMContext &Ctx, const llvm::Twine &Prefix,
                         const llvm::Twine &Desc);

--- a/llvm/tools/llvm-snippy/lib/Config/MemoryScheme.cpp
+++ b/llvm/tools/llvm-snippy/lib/Config/MemoryScheme.cpp
@@ -177,13 +177,28 @@ std::string yaml::MappingTraits<snippy::MemoryAccessRange>::validate(
     yaml::IO &Io, snippy::MemoryAccessRange &Range) {
   if (shouldSkipValidation(Io))
     return "";
-  // TODO: Remove this garbage and replace with a proper diagnostic
-  if (Range.FirstOffset > Range.LastOffset)
-    errs() << "Warning: first offset " << Range.FirstOffset << " > last offset "
-           << Range.LastOffset << "\n";
-  if (Range.LastOffset >= Range.Stride)
-    errs() << "Warning: last offset " << Range.LastOffset << " >= stride "
-           << Range.Stride << "\n";
+
+  if (Range.FirstOffset > Range.LastOffset) {
+    // TODO: Maybe this should become a hard error with the next breaking
+    // release?
+    snippy::warn(snippy::WarningName::MemoryAccess,
+                 "Invalid memory access range",
+                 Twine("'first-offset' (")
+                     .concat(Twine(Range.FirstOffset))
+                     .concat(") > 'last-offset' (")
+                     .concat(Twine(Range.LastOffset).concat(")")));
+  }
+
+  if (Range.LastOffset >= Range.Stride) {
+    // TODO: Maybe this should become a hard error with the next breaking
+    // release?
+    snippy::warn(snippy::WarningName::MemoryAccess,
+                 "Invalid memory access range",
+                 Twine("'last-offset' (")
+                     .concat(Twine(Range.LastOffset))
+                     .concat(") >= 'stride' (")
+                     .concat(Twine(Range.Stride).concat(")")));
+  }
 
   if (Range.Stride == 0)
     return "Stride cannot be equal to 0";

--- a/llvm/tools/llvm-snippy/lib/MemAccessDumperPass.cpp
+++ b/llvm/tools/llvm-snippy/lib/MemAccessDumperPass.cpp
@@ -108,8 +108,8 @@ void dumpMemAccesses(StringRef Filename, const PlainAccessesType &Plain,
                      const BurstGroupAccessesType &BurstRanges,
                      const PlainAccessesType &BurstPlain, bool Restricted) {
   if (Plain.empty() && BurstRanges.empty() && BurstPlain.empty()) {
-    errs() << "warning: cannot dump memory accesses as no accesses were "
-              "generated. File won't be created.\n";
+    snippy::warn(WarningName::MemoryAccess, "Cannot dump memory accesses",
+                 "No accesses were generated, file won't be created.");
     return;
   }
 

--- a/llvm/tools/llvm-snippy/llvm-snippy.cpp
+++ b/llvm/tools/llvm-snippy/llvm-snippy.cpp
@@ -455,12 +455,12 @@ static bool isParsingWithPluginEnabled() {
 
 static unsigned long long
 seedOptToValue(StringRef SeedStr, StringRef SeedType = "instructions seed",
-               StringRef Warning = "no instructions seed specified,"
-                                   " using auto-generated one: ") {
+               StringRef Warning =
+                   "no instructions seed specified, using auto-generated one") {
   if (SeedStr.empty()) {
     auto SeedValue =
         std::chrono::system_clock::now().time_since_epoch().count();
-    llvm::errs() << "warning: " << Warning << SeedValue << "\n";
+    snippy::warn(WarningName::SeedNotSpecified, Warning, Twine(SeedValue));
     return SeedValue;
   }
 


### PR DESCRIPTION
[snippy]: Color diagnostic output when possible

This patch rips out most of the incorrect diagnostics that write
to errs() directly and replaces them with proper `snippy::warn()` calls.

Now snippy::{fatal,warn,notice,remark} color their output for visibility.
We already had this behavior for YAML diagnostics, since those use SMDiagnostic,
which uses the same `WithColor` mechanism for coloring the output diagnostic severity.