### PR TITLE
[snippy] non-owning MAG

### DIFF
--- a/llvm/tools/llvm-snippy/include/snippy/Generator/RandomMemAccSampler.h
+++ b/llvm/tools/llvm-snippy/include/snippy/Generator/RandomMemAccSampler.h
@@ -15,7 +15,7 @@
 
 namespace llvm {
 namespace snippy {
-using MemoryAccessesGenerator = OwningMAG<MemoryAccessSeq>;
+using MemoryAccessesGenerator = MemAccGenerator<std::vector<MemoryAccess *>>;
 
 class RandomMemoryAccessSampler : public IMemoryAccessSampler {
   MemoryAccessSeq BaseAccesses;
@@ -24,7 +24,7 @@ class RandomMemoryAccessSampler : public IMemoryAccessSampler {
   MemoryBank RestrictedMB;
   MemoryBank MB;
 
-  MemoryAccessesGenerator MAG{MemoryAccessSeq{}};
+  MemoryAccessesGenerator MAG{std::vector<MemoryAccess *>{}};
 
 private:
   void updateMAG();

--- a/llvm/tools/llvm-snippy/include/snippy/Support/MemAccessGenerator.h
+++ b/llvm/tools/llvm-snippy/include/snippy/Support/MemAccessGenerator.h
@@ -134,22 +134,22 @@ public:
   void dump() const { print(dbgs()); }
 };
 
-template <typename ContT> class OwningMAG final {
+template <typename ContT> class MemAccGenerator final {
   ContT Accesses;
   MemoryAccessGenerator<typename ContT::iterator> MAG;
   size_t MAGId;
 
 public:
   // Id field should be unique only if this MAG is used in plugin interface
-  OwningMAG(ContT Container, size_t Id = 0)
+  MemAccGenerator(ContT Container, size_t Id = 0)
       : Accesses{std::move(Container)}, MAG{Accesses.begin(), Accesses.end()},
         MAGId{Id} {}
 
-  OwningMAG(OwningMAG<ContT> &&OldMAG)
+  MemAccGenerator(MemAccGenerator<ContT> &&OldMAG)
       : Accesses{std::move(OldMAG.Accesses)},
         MAG{Accesses.begin(), Accesses.end()}, MAGId{OldMAG.MAGId} {}
 
-  OwningMAG<ContT> &operator=(OwningMAG<ContT> &&Rhs) {
+  MemAccGenerator<ContT> &operator=(MemAccGenerator<ContT> &&Rhs) {
     Accesses = std::move(Rhs.Accesses);
     MAG = MemoryAccessGenerator<typename ContT::iterator>{Accesses.begin(),
                                                           Accesses.end()};
@@ -172,7 +172,8 @@ public:
 };
 
 // deduction guide for ContT
-template <typename ContT> OwningMAG(ContT, size_t) -> OwningMAG<ContT>;
+template <typename ContT>
+MemAccGenerator(ContT, size_t) -> MemAccGenerator<ContT>;
 
 } // namespace snippy
 } // namespace llvm

--- a/llvm/tools/llvm-snippy/lib/Generator/RandomMemAccSampler.cpp
+++ b/llvm/tools/llvm-snippy/lib/Generator/RandomMemAccSampler.cpp
@@ -35,10 +35,10 @@ void RandomMemoryAccessSampler::print(raw_ostream &OS) const {
 void RandomMemoryAccessSampler::updateMAG() {
   static auto MagCount = 0ull;
   MagCount++;
-  MemoryAccessSeq Schemes;
+  std::vector<MemoryAccess *> Schemes;
   for (auto &Scheme : make_range(SplitAccesses.begin(), SplitAccesses.end()))
-    Schemes.emplace_back(Scheme->copy());
-  MAG = OwningMAG{std::move(Schemes), MagCount};
+    Schemes.emplace_back(std::addressof(*Scheme));
+  MAG = MemAccGenerator{std::move(Schemes), MagCount};
 }
 
 MemoryAccessesGenerator &RandomMemoryAccessSampler::getMAG() {


### PR DESCRIPTION
Currently we use OwningMAG in which we copy all memory accesses. And we do this
for every instr-class (attributes combination). This leads not only to
excessive copies (that slow snippy down) but also to incorrectly working
ordered access-addresses schemes Now they are ordered inside each instr-class
and not across classes.