### PR TITLE
[snippy] Disable .bss initialization during loading elf to model

### DIFF
--- a/llvm/tools/llvm-snippy/include/snippy/Generator/Interpreter.h
+++ b/llvm/tools/llvm-snippy/include/snippy/Generator/Interpreter.h
@@ -127,7 +127,7 @@ public:
 
   void disableTransactionsTracking();
 
-  void loadElfImage(StringRef ElfImage);
+  void loadElfImage(StringRef ElfImage, bool InitBSS);
 
   void dumpCurrentRegState(StringRef Filename) const;
 

--- a/llvm/tools/llvm-snippy/include/snippy/Generator/SimRunner.h
+++ b/llvm/tools/llvm-snippy/include/snippy/Generator/SimRunner.h
@@ -44,7 +44,7 @@ public:
   // Each interpreter state will be reset before run.
   void run(const IRegisterState &InitialRegState, ProgramCounterType StartPC);
   // Loads image of program into each interpreter.
-  void loadElf(StringRef Image);
+  void loadElf(StringRef Image, bool InitBSS);
   auto &getSimConfig() & {
     assert(Env);
     return Env->SimCfg;

--- a/llvm/tools/llvm-snippy/lib/Generator/Interpreter.cpp
+++ b/llvm/tools/llvm-snippy/lib/Generator/Interpreter.cpp
@@ -262,7 +262,7 @@ static StringRef getSectionName(llvm::object::SectionRef S) {
     return "";
 }
 
-void Interpreter::loadElfImage(StringRef ElfImage) {
+void Interpreter::loadElfImage(StringRef ElfImage, bool InitBSS) {
   std::string ProgramText;
   auto MemBuff = MemoryBuffer::getMemBuffer(ElfImage, "", false);
   auto ObjectFile = makeObjectFile(*MemBuff);
@@ -288,7 +288,7 @@ void Interpreter::loadElfImage(StringRef ElfImage) {
             WarningName::EmptyElfSection,
             formatv("ignored LOAD section '{0}'", getSectionName(Section)),
             "empty contents");
-    } else if (Section.isBSS()) {
+    } else if (Section.isBSS() && InitBSS) {
       std::vector<char> Zeroes(Size, 0);
       Simulator->writeMem(Address, Zeroes);
     }

--- a/llvm/tools/llvm-snippy/lib/Generator/SimRunner.cpp
+++ b/llvm/tools/llvm-snippy/lib/Generator/SimRunner.cpp
@@ -34,9 +34,9 @@ SimRunner::SimRunner(LLVMContext &Ctx, const SnippyTarget &TGT,
   }
 }
 
-void SimRunner::loadElf(StringRef Image) {
+void SimRunner::loadElf(StringRef Image, bool InitBSS) {
   for (auto &I : CoInterp)
-    I->loadElfImage(Image);
+    I->loadElfImage(Image, InitBSS);
 }
 void SimRunner::run(const IRegisterState &InitialRegState,
                     ProgramCounterType StartPC) {

--- a/llvm/tools/llvm-snippy/lib/Generator/SimulatorContextWrapperPass.cpp
+++ b/llvm/tools/llvm-snippy/lib/Generator/SimulatorContextWrapperPass.cpp
@@ -222,7 +222,9 @@ void SimulatorContext::runSimulator(const RunInfo &RI) {
   }
 
   auto &SimRunner = getSimRunner();
-  SimRunner.loadElf(ImageToRun);
+  // FIXME: currently it does not initialize .bss sections with
+  // zeroes, to comply with legacy behaviour.
+  SimRunner.loadElf(ImageToRun, /* InitBSS */ false);
 
   SimRunner.run(InitRegState, StartPC);
 


### PR DESCRIPTION
[snippy] Disable .bss initialization during loading elf to model

This is done to comply with legacy behavior of previous versions that didn't
do that.