### PR TITLE
[snippy] Refactor error handling (NFC)

### DIFF
--- a/llvm/tools/llvm-snippy/include/snippy/Generator/GlobalsPool.h
+++ b/llvm/tools/llvm-snippy/include/snippy/Generator/GlobalsPool.h
@@ -34,11 +34,12 @@ public:
     CurrentOffset = NextOffset + Size;
     if (CurrentOffset > Desc.VMA + Desc.Size) {
       auto Overflow = CurrentOffset - (Desc.VMA + Desc.Size);
-      return make_error<Failure>("Out of space when allocating " + Twine(Size) +
-                                 " bytes (align " + Twine(Alignment) +
-                                 ") in section '" + Desc.getIDString() +
-                                 "' of size " + Twine(Desc.Size) + ". " +
-                                 Twine(Overflow) + " bytes overflow");
+      return makeFailure(Errc::OutOfSpace,
+                         "Out of space when allocating " + Twine(Size) +
+                             " bytes (align " + Twine(Alignment) +
+                             ") in section '" + Desc.getIDString() +
+                             "' of size " + Twine(Desc.Size) + ". " +
+                             Twine(Overflow) + " bytes overflow");
     }
     return NextOffset;
   }

--- a/llvm/tools/llvm-snippy/include/snippy/Generator/Policy.h
+++ b/llvm/tools/llvm-snippy/include/snippy/Generator/Policy.h
@@ -116,6 +116,8 @@ public:
   PreselectedOpInfo(llvm::Register R) : Value(R) {}
   PreselectedOpInfo(StridedImmediate Imm) : Value(Imm) {}
   PreselectedOpInfo() = default;
+  static Expected<PreselectedOpInfo> fromMCOperand(const MCOperand &Op);
+
   bool isReg() const { return std::holds_alternative<RegTy>(Value); }
   bool isImm() const { return std::holds_alternative<ImmTy>(Value); }
   bool isUnset() const { return std::holds_alternative<EmptyTy>(Value); }

--- a/llvm/tools/llvm-snippy/include/snippy/Support/DiagnosticInfo.h
+++ b/llvm/tools/llvm-snippy/include/snippy/Support/DiagnosticInfo.h
@@ -133,6 +133,13 @@ void warn(WarningName WN, const llvm::Twine &Prefix, const llvm::Twine &Desc);
 
 [[noreturn]] void fatal(const llvm::Twine &Desc);
 
+/// \brief Unwrap Expected value or fail with fatal error.
+template <typename T> T unwrapOrFatal(Expected<T> ValOrErr) {
+  if (!ValOrErr)
+    snippy::fatal("Unwrapping 'Expected' value", ValOrErr.takeError());
+  return std::move(*ValOrErr);
+}
+
 } // namespace snippy
 
 } // namespace llvm

--- a/llvm/tools/llvm-snippy/include/snippy/Support/Error.h
+++ b/llvm/tools/llvm-snippy/include/snippy/Support/Error.h
@@ -16,27 +16,45 @@
 namespace llvm {
 namespace snippy {
 
+enum class Errc {
+  // Skipping 0 value intentionally
+  Unimplemented = 1,
+  InvalidArgument,
+  OutOfRegisters,
+  InvalidConfiguration,
+  LogicError,
+  Failure,
+  OutOfSpace,
+};
+
+std::error_code makeErrorCode(Errc Code);
+
 // A class representing failures that happened within llvm-snippy, they are
-// used to report informations to the user.
+// used to report information to the user.
 class Failure : public StringError {
 public:
-  Failure(const Twine &S) : StringError(S, inconvertibleErrorCode()) {}
+  Failure(std::error_code EC, const Twine &S) : StringError(S, EC) {}
 
-  Failure(const Twine &Prefix, const Twine &Desc)
-      : StringError(Prefix + ": " + Desc, inconvertibleErrorCode()) {}
+  Failure(std::error_code EC, const Twine &Prefix, const Twine &Desc)
+      : StringError(Prefix + ": " + Desc, EC) {}
 };
+
+template <typename... Ts> Error makeFailure(std::error_code EC, Ts &&...Args) {
+  return make_error<Failure>(EC, std::forward<Ts>(Args)...);
+}
+
+template <typename... Ts> Error makeFailure(Errc EC, Ts &&...Args) {
+  return makeFailure(makeErrorCode(EC), std::forward<Ts>(Args)...);
+}
 
 class NoAvailableRegister : public Failure {
 public:
   NoAvailableRegister(const MCRegisterClass &RegClass,
                       const MCRegisterInfo &RegInfo, const Twine &Msg)
-      : Failure(Twine("No available register ") +
-                RegInfo.getRegClassName(&RegClass) + ": " + Msg) {}
+      : Failure(makeErrorCode(Errc::OutOfRegisters),
+                Twine("No available register ") +
+                    RegInfo.getRegClassName(&RegClass) + ": " + Msg) {}
 };
-
-inline void burrowError(Error E) {
-  handleAllErrors(std::move(E), [](const ErrorInfoBase &EI) {});
-}
 
 class MemoryAccessSampleError : public StringError {
 public:

--- a/llvm/tools/llvm-snippy/include/snippy/Support/RandUtil.h
+++ b/llvm/tools/llvm-snippy/include/snippy/Support/RandUtil.h
@@ -226,7 +226,8 @@ public:
   template <typename T>
   static Expected<std::vector<T>> getNInRangeInclusive(T Min, T Max, size_t N) {
     if (Max < Min)
-      return make_error<Failure>(
+      return makeFailure(
+          Errc::LogicError,
           "Invalid usage of genNUniqInInterval: Max cannot be less than Min.");
     std::vector<T> Vals(Max - Min + 1);
     std::generate(Vals.begin(), Vals.end(),
@@ -238,7 +239,8 @@ public:
   template <typename T>
   static Expected<std::vector<T>> genNUniqInInterval(T Min, T Max, size_t N) {
     if (Max < Min)
-      return make_error<Failure>(
+      return makeFailure(
+          Errc::LogicError,
           "Invalid usage of genNUniqInInterval: Max cannot be less than Min.");
     std::vector<T> Vals(Max - Min + 1);
     std::iota(Vals.begin(), Vals.end(), Min);
@@ -250,7 +252,8 @@ public:
   template <typename T, typename Pred>
   static Expected<size_t> countUniqInInterval(T Min, T Max, Pred Filter) {
     if (Max < Min)
-      return make_error<Failure>(
+      return makeFailure(
+          Errc::LogicError,
           "Invalid usage of countUniqInInterval: Max cannot be less than Min.");
 
     T K = Min;
@@ -269,10 +272,12 @@ public:
   static Expected<std::vector<T>> genNUniqInInterval(T Min, T Max, size_t N,
                                                      Pred Filter) {
     if (Max < Min)
-      return make_error<Failure>(
+      return makeFailure(
+          Errc::LogicError,
           "Invalid usage of genNUniqInInterval: Max cannot be less than Min.");
     if (Max - Min + 1 < N)
-      return make_error<Failure>(
+      return makeFailure(
+          Errc::LogicError,
           "Invalid usage of genNUniqInInterval: The interval has less unique "
           "values than was requested to generate.");
 
@@ -286,7 +291,8 @@ public:
     for (auto Next = G(); Next <= Max; Next = G())
       Vals.push_back(Next);
     if (Vals.size() < N)
-      return make_error<Failure>(
+      return makeFailure(
+          Errc::LogicError,
           "Invalid usage of genNUniqInInterval: The interval has less unique "
           "values than was requested.");
     shuffle(Vals.begin(), Vals.end());

--- a/llvm/tools/llvm-snippy/lib/Config/OpcodeHistogram.cpp
+++ b/llvm/tools/llvm-snippy/lib/Config/OpcodeHistogram.cpp
@@ -84,8 +84,8 @@ YAMLHistogramTraits<OpcodeHistogramDecodedEntry>::denormalizeEntry(
     yaml::IO &IO, StringRef OpcodeStr, double Weight) {
   Expected<OpcodeHistogramDecodedEntry> Decoded =
       decodeInstrRegex(IO, OpcodeStr, Weight);
-  if (auto E = Decoded.takeError()) {
-    IO.setError(toString(std::move(E)));
+  if (!Decoded) {
+    IO.setError(toString(Decoded.takeError()));
     return OpcodeHistogramDecodedEntry{};
   }
 

--- a/llvm/tools/llvm-snippy/lib/Config/RegisterHistogram.cpp
+++ b/llvm/tools/llvm-snippy/lib/Config/RegisterHistogram.cpp
@@ -323,8 +323,8 @@ template <> struct YAMLHistogramTraits<RegisterValuesEntry> {
         assert(Inserted);
       } else if (isRegWithClass(RegName)) {
         auto ExpectedClassIdx = getRegTypeAndIndex(RegName);
-        if (auto Err = ExpectedClassIdx.takeError(); Err)
-          Io.setError(toString(std::move(Err)));
+        if (!ExpectedClassIdx)
+          Io.setError(toString(ExpectedClassIdx.takeError()));
         auto [RegClass, Idx] = *ExpectedClassIdx;
         auto [ValuesIt, _] = RegClassToRegValues.try_emplace(RegClass.str());
         [[maybe_unused]] auto [ValIt, Inserted] =

--- a/llvm/tools/llvm-snippy/lib/Generator/LLVMState.cpp
+++ b/llvm/tools/llvm-snippy/lib/Generator/LLVMState.cpp
@@ -113,9 +113,9 @@ std::unique_ptr<MCStreamer> LLVMState::createObjStreamer(raw_pwrite_stream &OS,
   assert(TheTargetMachine);
   auto MCStreamerOrErr = TheTargetMachine->createMCStreamer(
       OS, nullptr, CodeGenFileType::ObjectFile, MCCtx);
-  if (auto Err = MCStreamerOrErr.takeError())
+  if (!MCStreamerOrErr)
     snippy::fatal(Ctx, "Internal Error creating MCStreamer",
-                  toString(std::move(Err)));
+                  toString(MCStreamerOrErr.takeError()));
 
   // We explicitly specified ObjectFile type 3 lines above so we can down-cast
   // it safely

--- a/llvm/tools/llvm-snippy/lib/Generator/RandomMemAccSampler.cpp
+++ b/llvm/tools/llvm-snippy/lib/Generator/RandomMemAccSampler.cpp
@@ -59,8 +59,8 @@ RandomMemoryAccessSampler::sample(size_t AccessSize, size_t Alignment,
   auto &MAGWithSchemes = getMAG();
   auto SchemeExp =
       MAGWithSchemes.getValidAccesses(AccessSize, Alignment, BurstMode);
-  if (auto Err = SchemeExp.takeError())
-    return Expected<AccessSampleResult>(std::move(Err));
+  if (!SchemeExp)
+    return Expected<AccessSampleResult>(SchemeExp.takeError());
   auto &Scheme = *SchemeExp;
   auto AddrGenInfo = ChooseAddrGenInfo(*Scheme);
   auto AI = Scheme->randomAddress(AddrGenInfo);

--- a/llvm/tools/llvm-snippy/lib/Generator/SnippyModule.cpp
+++ b/llvm/tools/llvm-snippy/lib/Generator/SnippyModule.cpp
@@ -114,7 +114,8 @@ SnippyProgramContext::getOrAddGlobalsPoolFor(Module &M) {
   if (PerModuleGPs.count(Key))
     return *PerModuleGPs.at(Key);
   if (!ROMSection)
-    return make_error<Failure>("ROM section is not configured");
+    return makeFailure(Errc::InvalidConfiguration,
+                       "ROM section is not configured");
 
   return *PerModuleGPs
               .emplace(Key, std::make_unique<GlobalsPool>(

--- a/llvm/tools/llvm-snippy/lib/Generator/TopMemAccSampler.cpp
+++ b/llvm/tools/llvm-snippy/lib/Generator/TopMemAccSampler.cpp
@@ -20,8 +20,8 @@ Expected<AccessSampleResult> TopLevelMemoryAccessSampler::sample(
   for (auto &&[Idx, S] : enumerate(Samplers)) {
     auto Access =
         S->sample(AccessSize, Alignment, ChooseAddrGenInfo, BurstMode);
-    if (auto Err = Access.takeError()) {
-      Errs[Idx] = toString(std::move(Err));
+    if (!Access) {
+      Errs[Idx] = toString(Access.takeError());
       continue;
     }
     return *Access;
@@ -45,9 +45,9 @@ std::vector<AddressInfo> TopLevelMemoryAccessSampler::randomBurstGroupAddresses(
 
     auto Access = sample(AR.AccessSize, AR.AccessAlignment,
                          /*BurstMode*/ true);
-    if (auto Err = Access.takeError())
+    if (!Access)
       snippy::fatal("Failed to sample memory access for burst group",
-                    toString(std::move(Err)));
+                    toString(Access.takeError()));
     auto &AI = Access->AddrInfo;
     Addresses.push_back(std::move(AI));
   }

--- a/llvm/tools/llvm-snippy/lib/Support/CMakeLists.txt
+++ b/llvm/tools/llvm-snippy/lib/Support/CMakeLists.txt
@@ -2,15 +2,16 @@ add_llvm_library(
   LLVMSnippySupport
   DISABLE_LLVM_LINK_LLVM_DYLIB
   STATIC
+  APIntSampler.cpp
   DiagnosticInfo.cpp
   DynLibLoader.cpp
+  Error.cpp
   OpcodeCache.cpp
-  Options.cpp
   OpcodeGenerator.cpp
+  Options.cpp
   RandUtil.cpp
   Utils.cpp
-  YAMLUtils.cpp
-  APIntSampler.cpp)
+  YAMLUtils.cpp)
 
 if(LLVM_SNIPPY_NEEDS_LIBSTDCPP_FS)
   target_link_libraries(LLVMSnippySupport PRIVATE stdc++fs)

--- a/llvm/tools/llvm-snippy/lib/Support/Error.cpp
+++ b/llvm/tools/llvm-snippy/lib/Support/Error.cpp
@@ -1,0 +1,46 @@
+//===-- Error.cpp -----------------------------------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "snippy/Support/Error.h"
+
+namespace llvm {
+namespace snippy {
+
+class SnippyErrorCategory : public std::error_category {
+  const char *name() const noexcept override { return "snippy"; }
+  std::string message(int ErrorValue) const override;
+};
+
+std::string SnippyErrorCategory::message(int ErrorValue) const {
+  switch (static_cast<Errc>(ErrorValue)) {
+  case Errc::Unimplemented:
+    return "Unimplemented";
+  case Errc::InvalidArgument:
+    return "Invalid argument";
+  case Errc::OutOfRegisters:
+    return "No available registers";
+  case Errc::InvalidConfiguration:
+    return "Invalid configuration";
+  case Errc::LogicError:
+    return "Logic error";
+  case Errc::Failure:
+    return "Failure";
+  case Errc::OutOfSpace:
+    return "Out of available space";
+  }
+
+  return "Unrecognized error code";
+}
+
+std::error_code makeErrorCode(Errc Code) {
+  static const SnippyErrorCategory TheSnippyErrorCategory;
+  return std::error_code(static_cast<int>(Code), TheSnippyErrorCategory);
+}
+
+} // namespace snippy
+} // namespace llvm


### PR DESCRIPTION
\[snippy\] Refactor error handling (NFC)

Get rid of the illegal pattern:

```{.cpp}
if (auto Err = Expected.takeError()) {
  ....
}
someUsage(*Expected);
```

This is not allowed because of the implicit postcondition for Expected::takeError():

> Take ownership of the stored error. After calling this the Expected is in an indeterminate state that can only be safely destructed. No further calls (beside the destructor) should be made on the Expected value.