### PR TITLE
[snippy] add liveness when using init-regs-in-elf

### DIFF
--- a/llvm/test/tools/llvm-snippy/init-regs-in-elf-liveness.yaml
+++ b/llvm/test/tools/llvm-snippy/init-regs-in-elf-liveness.yaml
@@ -1,0 +1,34 @@
+# RUN: llvm-snippy %s -model-plugin=None -verify-mi -dump-mir=- | FileCheck %s
+
+options:
+  march: riscv64-unknown-elf
+  init-regs-in-elf: true
+  num-instrs: 100
+  mattr: "+f"
+
+sections:
+    - name:      text
+      VMA:       0x1000
+      SIZE:      0x10000
+      LMA:       0x1000
+      ACCESS:    rx
+    - name:      data
+      VMA:       0x80000000
+      SIZE:      0x400000
+      LMA:       0x80000000
+      ACCESS:    rw
+
+histogram:
+    - [ADD, 1.0]
+    - [SUB, 1.0]
+    - [FADD_S, 1.0]
+    - [FSUB_S, 1.0]
+
+#CHECK: bb.0:
+#CHECK-NEXT: liveins: $x0, $x1, $x2, $x3, $x4, $x5, $x6, $x7, $x8, $x9, $x10,
+#CHECK-SAME: $x11, $x12, $x13, $x14, $x15, $x16, $x17, $x18, $x19, $x20, $x21,
+#CHECK-SAME: $x22, $x23, $x24, $x25, $x26, $x27, $x28, $x29, $x30, $x31, $f0_f,
+#CHECK-SAME: $f1_f, $f2_f, $f3_f, $f4_f, $f5_f, $f6_f, $f7_f, $f8_f, $f9_f,
+#CHECK-SAME: $f10_f, $f11_f, $f12_f, $f13_f, $f14_f, $f15_f, $f16_f, $f17_f,
+#CHECK-SAME: $f18_f, $f19_f, $f20_f, $f21_f, $f22_f, $f23_f, $f24_f, $f25_f,
+#CHECK-SAME: $f26_f, $f27_f, $f28_f, $f29_f, $f30_f, $f31_f

--- a/llvm/tools/llvm-snippy/include/snippy/Target/Target.h
+++ b/llvm/tools/llvm-snippy/include/snippy/Target/Target.h
@@ -246,6 +246,11 @@ public:
   virtual void generateRegsInit(InstructionGenerationContext &IGC,
                                 const IRegisterState &R) const = 0;
 
+  virtual void
+  markAllAvailableRegistersAsLiveIns(InstructionGenerationContext &IGC,
+                                     MachineBasicBlock &MBB,
+                                     const IRegisterState &R) const = 0;
+
   virtual void generateCustomInst(
       const MCInstrDesc &InstrDesc,
       planning::InstructionGenerationContext &InstrGenCtx) const = 0;

--- a/llvm/tools/llvm-snippy/lib/Generator/FunctionGeneratorPass.cpp
+++ b/llvm/tools/llvm-snippy/lib/Generator/FunctionGeneratorPass.cpp
@@ -181,9 +181,8 @@ MachineFunction &FunctionGenerator::createFunction(
   auto &GenSettings = SGCtx.getGenSettings();
   auto &OpCC = ProgCtx.getOpcodeCache();
   // FIXME: currently we don't keep liveness when creating and filling new BB
-  auto IsRegsInit = GenSettings.RegistersConfig.InitializeRegs;
   if (GenSettings.hasCFInstrs(OpCC) ||
-      GenSettings.hasCallInstrs(OpCC, SnippyTgt) || IsRegsInit)
+      GenSettings.hasCallInstrs(OpCC, SnippyTgt))
     Props.reset(MachineFunctionProperties::Property::TracksLiveness);
   auto *MBB = createMachineBasicBlock(MF);
   assert(MBB);

--- a/llvm/tools/llvm-snippy/lib/RegsInitInsertionPass.cpp
+++ b/llvm/tools/llvm-snippy/lib/RegsInitInsertionPass.cpp
@@ -93,11 +93,14 @@ bool RegsInitInsertion::runOnMachineFunction(MachineFunction &MF) {
   MF.insert(InsertIterPos, BlockRegsInit);
   SFM.RegsInitBlock = BlockRegsInit;
 
+  const auto &RegState =
+      SGCtx.getProgramContext().getInitialRegisterState(SubTgt);
   planning::InstructionGenerationContext IGC{
       *BlockRegsInit, BlockRegsInit->getFirstTerminator(), SGCtx, SimCtx};
 
-  SnippyTgt.generateRegsInit(
-      IGC, SGCtx.getProgramContext().getInitialRegisterState(SubTgt));
+  SnippyTgt.markAllAvailableRegistersAsLiveIns(IGC, *SuccessorBlockPtr,
+                                               RegState);
+  SnippyTgt.generateRegsInit(IGC, RegState);
   return true;
 }
 

--- a/llvm/tools/llvm-snippy/lib/Target/RISCV/Target.cpp
+++ b/llvm/tools/llvm-snippy/lib/Target/RISCV/Target.cpp
@@ -1168,6 +1168,24 @@ public:
       snippy::fatal("Lr.rl and Sc.aq are prohibited by RISCV ISA");
   }
 
+  void
+  markAllAvailableRegistersAsLiveIns(InstructionGenerationContext &IGC,
+                                     MachineBasicBlock &MBB,
+                                     const IRegisterState &R) const override {
+    const auto &Regs = static_cast<const RISCVRegisterState &>(R);
+    auto AddLiveInForRegGroup = [&](const auto &Regs, RegStorageType RegType) {
+      for (unsigned RegIdx = 0; RegIdx < Regs.size(); ++RegIdx) {
+        auto MCReg = regIndexToMCReg(IGC, RegIdx, RegType);
+        if (!MBB.isLiveIn(MCReg))
+          MBB.addLiveIn(MCReg);
+      }
+    };
+
+    AddLiveInForRegGroup(Regs.XRegs, RegStorageType::XReg);
+    AddLiveInForRegGroup(Regs.FRegs, RegStorageType::FReg);
+    AddLiveInForRegGroup(Regs.VRegs, RegStorageType::VReg);
+  }
+
   void generateRegsInit(InstructionGenerationContext &IGC,
                         const IRegisterState &R) const override {
     const auto &Regs = static_cast<const RISCVRegisterState &>(R);

--- a/llvm/tools/llvm-snippy/lib/Target/X86/Target.cpp
+++ b/llvm/tools/llvm-snippy/lib/Target/X86/Target.cpp
@@ -59,6 +59,13 @@ public:
     reportUnimplementedError();
   }
 
+  void
+  markAllAvailableRegistersAsLiveIns(InstructionGenerationContext &IGC,
+                                     MachineBasicBlock &MBB,
+                                     const IRegisterState &R) const override {
+    reportUnimplementedError();
+  }
+
   bool needsGenerationPolicySwitch(unsigned Opcode) const override {
     reportUnimplementedError();
   }


### PR DESCRIPTION
[snippy] add a method for adding livein registers for basic block