### PR TITLE
[snippy] Change default model-plugin to None

### DIFF
--- a/llvm/test/tools/llvm-snippy/default-model.test
+++ b/llvm/test/tools/llvm-snippy/default-model.test
@@ -1,0 +1,5 @@
+# COM: llvm-snippy is not used directly, because substitutions here will
+# COM: mess up default options. layout file is also unspecified to skip actual
+# COM: generation.
+# RUN: %llvm_tools/llvm-snippy -dump-options -march riscv64-unknown-elf
+# CHECK: model-plugin: None

--- a/llvm/tools/llvm-snippy/llvm-snippy.cpp
+++ b/llvm/tools/llvm-snippy/llvm-snippy.cpp
@@ -284,9 +284,10 @@ static snippy::opt<std::string>
 
 static snippy::opt<std::string> ModelPluginFile(
     "model-plugin",
-    cl::desc("Primary model plugin to use for snippet generation"
-             "Use =None to disable snippet execution on the model."),
-    cl::value_desc("filename"), cl::cat(Options), cl::init("libRISCVModel.so"));
+    cl::desc(
+        "Primary model plugin to use for snippet generation. Use 'None' to "
+        "disable snippet execution on the model."),
+    cl::value_desc("alias|filename"), cl::cat(Options), cl::init("None"));
 
 static snippy::opt_list<std::string>
     CoSimModelPluginFilesList("cosim-model-plugins", cl::CommaSeparated,


### PR DESCRIPTION
[snippy] Change default model-plugin to None

Fixes https://github.com/syntacore/snippy/issues/17