### PR TITLE
[snippy] Diagnose unrecognized cpu for subtarget

### DIFF
--- a/llvm/test/tools/llvm-snippy/invalid-cpu-fail.test
+++ b/llvm/test/tools/llvm-snippy/invalid-cpu-fail.test
@@ -1,0 +1,6 @@
+# RUN: not llvm-snippy \
+# RUN:   -march riscv64-unknown-elf -mcpu fake-cpu |& \
+# RUN:   FileCheck %s --check-prefix CHECK-FAKE
+
+# CHECK-FAKE: 'fake-cpu' is not a recognized processor for this target (ignoring processor)
+# CHECK-FAKE: error: cpu 'fake-cpu' is not valid for the specified subtarget

--- a/llvm/test/tools/llvm-snippy/void-param-list.yaml
+++ b/llvm/test/tools/llvm-snippy/void-param-list.yaml
@@ -1,5 +1,5 @@
 # REQUIRES: x86-registered-target
 # RUN: not llvm-snippy  |& FileCheck %s
 
-# CHECK: error: sorry,{{[ X86]*}} target is not implemented
+# CHECK: error: No snippy target for x86_64-unknown-linux-gnu
 # CHECK-NOT: Aborted (core dumped)

--- a/llvm/tools/llvm-snippy/llvm-snippy.cpp
+++ b/llvm/tools/llvm-snippy/llvm-snippy.cpp
@@ -350,7 +350,10 @@ static DebugOptions getDebugOptions() {
 void generateMain() {
   initializeLLVMAll();
   readSnippyOptionsIfNeeded();
-  auto State = LLVMState(getSelectedTargetInfo());
+  auto ExpectedState = LLVMState::create(getSelectedTargetInfo());
+  if (!ExpectedState)
+    snippy::fatal(ExpectedState.takeError());
+  auto &State = ExpectedState.get();
   checkOptions(State.getCtx());
   OpcodeCache OpCC(State.getSnippyTarget(), State.getInstrInfo(),
                    State.getSubtargetInfo());


### PR DESCRIPTION
[snippy] Diagnose unrecognized cpu for subtarget

Refactor LLVMState to make constructor failable and add
missing special member functions.

Add diagnostics for unrecognized cpu name for earlier
and more concise error messages.