### PR TITLE
[snippy] Configurable Werror and Wno-error options

### DIFF
--- a/llvm/test/tools/llvm-snippy/dump-options-without-layout.test
+++ b/llvm/test/tools/llvm-snippy/dump-options-without-layout.test
@@ -5,6 +5,7 @@
 # COM: Check that the stderr is not cluttered.
 # RUN: [ ! -s %t.stderr ]
 
-# CHECK-DAG: werror:
+# CHECK-DAG: Werror:
+# CHECK-DAG: Wno-error:
 # CHECK-DAG: seed:
 # CHECK-DAG: num-instrs:

--- a/llvm/test/tools/llvm-snippy/lit.local.cfg
+++ b/llvm/test/tools/llvm-snippy/lit.local.cfg
@@ -17,7 +17,7 @@ SnippyTool = ToolSubst(
     'llvm-snippy',
     command=FindTool('llvm-snippy'),
     unresolved='ignore',
-    extra_args=[f'-seed={Seed}', '-o', '%t_elf.out', '-model-plugin', SnippyModel])
+    extra_args=[f'-seed={Seed}', '-o', '%t_elf.out', '-model-plugin', SnippyModel, '-Wno-error=non-reproducible-execution'])
 
 config.substitutions.append(("%llvm_tools", str(config.llvm_tools_dir)))
 

--- a/llvm/test/tools/llvm-snippy/non-reproducible-exec-error.yaml
+++ b/llvm/test/tools/llvm-snippy/non-reproducible-exec-error.yaml
@@ -1,0 +1,26 @@
+# COM: llvm-snippy is not used directly, because substitutions here will
+# COM: mess up default options.
+
+# RUN: not %llvm_tools/llvm-snippy %s -march=riscv64-unknown-elf -model-plugin=some/path \
+# RUN:   |& FileCheck %s
+
+sections:
+    - no:        1
+      VMA:       0x100000
+      SIZE:      0x100000
+      LMA:       0x100000
+      ACCESS:    rx
+    - no:        2
+      VMA:       0x800000
+      SIZE:      0x400000
+      LMA:       0x800000
+      ACCESS:    rw
+
+histogram:
+    - [LD, 1.0]
+
+# CHECK: error: (non-reproducible-execution) Execution on model without
+# CHECK-SAME: "init-regs-in-elf" option enabled
+# CHECK-SAME: Enable explicit register initialization
+
+

--- a/llvm/test/tools/llvm-snippy/wdisable-option.yaml
+++ b/llvm/test/tools/llvm-snippy/wdisable-option.yaml
@@ -1,9 +1,9 @@
 # RUN: llvm-snippy %s --model-plugin None |& FileCheck %s --check-prefix=WARN
 # RUN: llvm-snippy %s --model-plugin None \
-# RUN:   -wdisable=memory-access,unused-section,no-model-exec \
+# RUN:   -Wdisable=memory-access,unused-section,no-model-exec \
 # RUN:   |& FileCheck %s --check-prefix=NOWARN
 # RUN: llvm-snippy %s --model-plugin None \
-# RUN:   -wdisable=memory-access,unused-section \
+# RUN:   -Wdisable=memory-access,unused-section \
 # RUN:   |& FileCheck %s --check-prefix=SOMEWARN
 
 options:

--- a/llvm/test/tools/llvm-snippy/wdisable-unknown.yaml
+++ b/llvm/test/tools/llvm-snippy/wdisable-unknown.yaml
@@ -1,5 +1,5 @@
 # RUN: not llvm-snippy %s --model-plugin None \
-# RUN:   -wdisable=no-model-exec,alien-invasions,no-coffee \
+# RUN:   -Wdisable=no-model-exec,alien-invasions,no-coffee \
 # RUN:   |& FileCheck %s
 
 options:
@@ -39,5 +39,5 @@ access-ranges:
     first-offset: 0
     last-offset: 0
 
-# CHECK: error: Unknown warning category specified for -wdisable option:
+# CHECK: error: Unknown warning category specified for "Wdisable" option:
 # CHECK-SAME: List of unknown warning categories: "alien-invasions", "no-coffee"

--- a/llvm/test/tools/llvm-snippy/werror.yaml
+++ b/llvm/test/tools/llvm-snippy/werror.yaml
@@ -1,4 +1,4 @@
-# RUN: not llvm-snippy %s -march=riscv64-linux-gnu  -werror --model-plugin=None \
+# RUN: not llvm-snippy %s -march=riscv64-linux-gnu  -Werror --model-plugin=None \
 # RUN: -num-instrs=10 |& FileCheck %s --dump-input always
 
 sections:

--- a/llvm/test/tools/llvm-snippy/wno-error.yaml
+++ b/llvm/test/tools/llvm-snippy/wno-error.yaml
@@ -1,0 +1,52 @@
+# COM: llvm-snippy is not used directly, because substitutions here will
+# COM: mess up default options.
+
+# RUN: not %llvm_tools/llvm-snippy %s -march=riscv64-linux-gnu  \
+# RUN:   -Werror=memory-access,no-model-exec \
+# RUN:   --model-plugin=None -Wno-error=memory-access -num-instrs=10 \
+# RUN:   |& FileCheck %s
+
+# RUN: %llvm_tools/llvm-snippy %s -march=riscv64-linux-gnu --model-plugin=None \
+# RUN:   -Werror=memory-access,no-model-exec -o %t  \
+# RUN:   -Wno-error=no-model-exec,memory-access -num-instrs=10 \
+# RUN:   |& FileCheck %s --check-prefix=PASS
+ 
+# RUN: %llvm_tools/llvm-snippy %s -march=riscv64-linux-gnu --model-plugin=None \
+# RUN:   -Werror=memory-access,no-model-exec \
+# RUN:   -Wno-error -num-instrs=10 -o %t \
+# RUN:   |& FileCheck %s --check-prefix=PASS
+
+# RUN: not %llvm_tools/llvm-snippy %s -march=riscv64-linux-gnu  -Werror --model-plugin=None \
+# RUN:   -Wno-error=foo,bar -num-instrs=10 \
+# RUN:   |& FileCheck %s --check-prefix=UNKNOWN
+
+sections:
+    - no:        1
+      VMA:       0x100000
+      SIZE:      0x100000
+      LMA:       0x100000
+      ACCESS:    rx
+    - no:        2
+      VMA:       0x800000
+      SIZE:      0x400000
+      LMA:       0x800000
+      ACCESS:    rw
+
+histogram:
+    - [ADD, 1.0]
+
+access-ranges:
+  - start: 0x1000
+    size: 0x100
+    stride: 0x10
+    first-offset: 0
+    last-offset: 10
+
+# CHECK: warning: (memory-access) Possibly wrong memory scheme
+# CHECK: error: (no-model-exec) Skipping snippet execution on the model: model was set no 'None'.
+
+# PASS: warning: (memory-access) Possibly wrong memory scheme
+# PASS: warning: (no-model-exec) Skipping snippet execution on the model: model was set no 'None'.
+
+# UNKNOWN: error: Unknown warning category specified for "Wno-error" option
+# UNKNOWN-SAME: List of unknown warning categories: "foo", "bar"

--- a/llvm/tools/llvm-snippy/include/snippy/Support/DiagnosticInfo.h
+++ b/llvm/tools/llvm-snippy/include/snippy/Support/DiagnosticInfo.h
@@ -41,7 +41,8 @@ namespace snippy {
   WARN_CASE(UnusedSection, "unused-section")                                   \
   WARN_CASE(EmptyElfSection, "empty-elf-section")                              \
   WARN_CASE(GenPlanVerification, "gen-plan-verification")                      \
-  WARN_CASE(SeedNotSpecified, "seed-not-specified")
+  WARN_CASE(SeedNotSpecified, "seed-not-specified")                            \
+  WARN_CASE(NonReproducibleExecution, "non-reproducible-execution")
 
 #ifdef WARN_CASE
 #error WARN_CASE should not be defined at this point

--- a/llvm/tools/llvm-snippy/lib/Config/Config.cpp
+++ b/llvm/tools/llvm-snippy/lib/Config/Config.cpp
@@ -21,6 +21,7 @@
 #include "snippy/Target/Target.h"
 
 #include "llvm/Support/Errc.h"
+#include "llvm/Support/FormatVariadic.h"
 #include "llvm/Support/Path.h"
 #include "llvm/Support/YAMLTraits.h"
 #include <istream>
@@ -1152,6 +1153,19 @@ void Config::validateAll(LLVMState &State, const OpcodeCache &OpCC,
   auto &Tgt = State.getSnippyTarget();
   auto &TM = State.getTargetMachine();
   auto &CGLayout = PassCfg.CGLayout;
+  if (PassCfg.ModelPluginConfig.runOnModel() && !InitRegsInElf)
+    snippy::warn(
+        WarningName::NonReproducibleExecution,
+        formatv("Execution on model without \"{0}\" option enabled will lead "
+                "to non-reproducible execution as register will be assumed to "
+                "be initialized with random values",
+                InitRegsInElf.ArgStr),
+        formatv("Enable explicit register initialization with option \"{0}\" "
+                "or dump random initial values with option \"{1}\" and suppres "
+                "with \"-Wno-error\" option",
+                InitRegsInElf.ArgStr, DumpInitialRegisters.ArgStr)
+
+    );
   if (std::holds_alternative<CallGraphLayout>(CGLayout))
     std::get<CallGraphLayout>(CGLayout).validate(Ctx);
   const auto &Sections = ProgramCfg->Sections;


### PR DESCRIPTION
[snippy] Configurable Werror and Wno-error options

This commit implements some new functionality to handle warning and
error reporting. New -Werror option can now accept a list of warning
categories that should be treated like errors (empty means all). New
-Wno-error option allows to disable reporting errors on selected warning
categories even if -Werror is enabled for them. This commit also adds
new diagnostic (non-reproducible-execution) that prevents using model
execution without register initialization as it will lead to non
reproducible execution