### PR TITLE
[snippy][RISCV] Improve FP support

### DIFF
--- a/llvm/lib/Target/RISCV/RISCVInstrInfo.td
+++ b/llvm/lib/Target/RISCV/RISCVInstrInfo.td
@@ -1800,6 +1800,9 @@ def WriteVXRMImm : WriteSysRegImm<SysRegVXRM, [VXRM]>;
 let hasSideEffects = true in {
 def ReadFFLAGS : ReadSysReg<SysRegFFLAGS, [FFLAGS]>;
 def WriteFFLAGS : WriteSysReg<SysRegFFLAGS, [FFLAGS]>;
+// Needed only for llvm-snippy.
+def WriteFFLAGSImm : WriteSysRegImm<SysRegFFLAGS, [FFLAGS]>;
+def SwapFFLAGSImm : SwapSysRegImm<SysRegFFLAGS, [FFLAGS]>;
 }
 /// Other pseudo-instructions
 

--- a/llvm/test/tools/llvm-snippy/floating-point/float-different-rounding-modes-imm-hist.yaml
+++ b/llvm/test/tools/llvm-snippy/floating-point/float-different-rounding-modes-imm-hist.yaml
@@ -1,0 +1,45 @@
+# RUN: llvm-snippy %s | FileCheck %s
+
+include:
+  - ../Inputs/sections.yaml
+options:
+  march: riscv64-unknown-elf
+  mcpu: generic-rv64
+  mattr: "+f"
+  num-instrs: 1000
+  dump-mf: true
+histogram:
+  - [FADD_S, 1.0]
+  - [FSUB_S, 1.0]
+imm-hist:
+  opcodes:
+    - "FADD_S":
+        - [7, 1.0] # DYN
+    - "FSUB_S":
+        - [0, 1.0] # RNE
+
+# COM: RNE - 0b000
+# COM: RTZ - 0b001
+# COM: RDN - 0b010
+# COM: RUP - 0b011
+# COM: RMM - 0b100
+# COM: DYN - 0b111
+
+# CHECK-DAG: [[REG:\$f[[:digit:]]+_f]] = FADD_S {{.*}}, 7
+# CHECK-DAG: [[REG:\$f[[:digit:]]+_f]] = FSUB_S {{.*}}, 0
+
+# CHECK-NOT: [[REG:\$f[[:digit:]]+_f]] = FADD_S {{.*}}, 0
+# CHECK-NOT: [[REG:\$f[[:digit:]]+_f]] = FADD_S {{.*}}, 1
+# CHECK-NOT: [[REG:\$f[[:digit:]]+_f]] = FADD_S {{.*}}, 2
+# CHECK-NOT: [[REG:\$f[[:digit:]]+_f]] = FADD_S {{.*}}, 3
+# CHECK-NOT: [[REG:\$f[[:digit:]]+_f]] = FADD_S {{.*}}, 4
+# CHECK-NOT: [[REG:\$f[[:digit:]]+_f]] = FADD_S {{.*}}, 5
+# CHECK-NOT: [[REG:\$f[[:digit:]]+_f]] = FADD_S {{.*}}, 6
+
+# CHECK-NOT: [[REG:\$f[[:digit:]]+_f]] = FSUB_S {{.*}}, 1
+# CHECK-NOT: [[REG:\$f[[:digit:]]+_f]] = FSUB_S {{.*}}, 2
+# CHECK-NOT: [[REG:\$f[[:digit:]]+_f]] = FSUB_S {{.*}}, 3
+# CHECK-NOT: [[REG:\$f[[:digit:]]+_f]] = FSUB_S {{.*}}, 4
+# CHECK-NOT: [[REG:\$f[[:digit:]]+_f]] = FSUB_S {{.*}}, 5
+# CHECK-NOT: [[REG:\$f[[:digit:]]+_f]] = FSUB_S {{.*}}, 6
+# CHECK-NOT: [[REG:\$f[[:digit:]]+_f]] = FSUB_S {{.*}}, 7

--- a/llvm/test/tools/llvm-snippy/floating-point/float-different-rounding-modes.yaml
+++ b/llvm/test/tools/llvm-snippy/floating-point/float-different-rounding-modes.yaml
@@ -16,9 +16,11 @@ histogram:
 # COM: RDN - 0b010
 # COM: RUP - 0b011
 # COM: RMM - 0b100
+# COM: DYN - 0b111
 
 # CHECK-DAG: [[REG:\$f[[:digit:]]+_f]] = FADD_S {{.*}}, 0
 # CHECK-DAG: [[REG:\$f[[:digit:]]+_f]] = FADD_S {{.*}}, 1
 # CHECK-DAG: [[REG:\$f[[:digit:]]+_f]] = FADD_S {{.*}}, 2
 # CHECK-DAG: [[REG:\$f[[:digit:]]+_f]] = FADD_S {{.*}}, 3
 # CHECK-DAG: [[REG:\$f[[:digit:]]+_f]] = FADD_S {{.*}}, 4
+# CHECK-DAG: [[REG:\$f[[:digit:]]+_f]] = FADD_S {{.*}}, 7

--- a/llvm/test/tools/llvm-snippy/floating-point/float-read-write-fflags-imm-hist.yaml
+++ b/llvm/test/tools/llvm-snippy/floating-point/float-read-write-fflags-imm-hist.yaml
@@ -1,0 +1,22 @@
+# RUN: llvm-snippy %s -mattr +f,-d -model-plugin None -o %t
+# RUN: llvm-objdump %t.elf -d |& FileCheck %s -dump-input fail
+# RUN: llvm-snippy %s -mattr +d -model-plugin None -o %t
+# RUN: llvm-objdump %t.elf -d |& FileCheck %s -dump-input fail
+include:
+  - ../Inputs/sections.yaml
+options:
+  march: riscv64-unknown-elf
+  mcpu: generic-rv64
+  num-instrs: 1000
+histogram:
+  - [ReadFFLAGS, 1.0]
+  - [WriteFFLAGSImm, 1.0]
+  - [SwapFFLAGSImm, 1.0]
+imm-hist:
+  opcodes:
+    - "WriteFFLAGSImm|SwapFFLAGSImm":
+        - [0, 1.0] # Clear flags
+
+# CHECK-DAG: frflags {{[sat][[:digit:]]+}}
+# CHECK-DAG: fsflagsi {{[sat][[:digit:]]+}}, 0x0
+# CHECK-DAG: fsflagsi 0x0

--- a/llvm/test/tools/llvm-snippy/floating-point/float-read-write-frm-imm-hist.yaml
+++ b/llvm/test/tools/llvm-snippy/floating-point/float-read-write-frm-imm-hist.yaml
@@ -1,0 +1,38 @@
+# RUN: llvm-snippy %s -mattr +f,-d -model-plugin None -o %t
+# RUN: llvm-objdump %t.elf -d |& FileCheck %s -dump-input fail
+# RUN: llvm-snippy %s -mattr +d -model-plugin None -o %t
+# RUN: llvm-objdump %t.elf -d |& FileCheck %s -dump-input fail
+include:
+  - ../Inputs/sections.yaml
+options:
+  march: riscv64-unknown-elf
+  mcpu: generic-rv64
+  num-instrs: 2000
+histogram:
+  - [WriteFRMImm, 1.0]
+  - [SwapFRMImm, 1.0]
+  - [ReadFRM, 1.0]
+imm-hist:
+  opcodes:
+    - "WriteFRMImm|SwapFRMImm":
+        - [0, 1.0] # RNE
+        - [1, 1.0] # RTZ
+        - [2, 1.0] # RDN
+        - [3, 1.0] # RUP
+        - [4, 1.0] # RMM
+
+# CHECK-DAG: fsrmi {{[sat][[:digit:]]+,}} 0x0
+# CHECK-DAG: fsrmi 0x0
+# CHECK-DAG: fsrmi {{[sat][[:digit:]]+,}} 0x1
+# CHECK-DAG: fsrmi 0x1
+# CHECK-DAG: fsrmi {{[sat][[:digit:]]+,}} 0x2
+# CHECK-DAG: fsrmi 0x2
+# CHECK-DAG: fsrmi {{[sat][[:digit:]]+,}} 0x3
+# CHECK-DAG: fsrmi 0x3
+# CHECK-DAG: fsrmi {{[sat][[:digit:]]+,}} 0x4
+# CHECK-DAG: fsrmi 0x4
+# CHECK-DAG: frrm {{[sat][[:digit:]]+}}
+
+# CHECK-NOT: fsrmi 0x5
+# CHECK-NOT: fsrmi 0x6
+# CHECK-NOT: fsrmi 0x7


### PR DESCRIPTION
[snippy][RISCV] Improve FP support

This patch exposes and adds several pseudoinstructions:

For reading and clearing fflags:

- `ReadFFLAGS`
- `WriteFFLAGSImm`
- `SwapFFLAGSImm`

For reading and modifying the rounding modes:

- `ReadFRM`
- `WriteFRMImm`
- `SwapFRMImm`

It's now also possible to specify rounding modes on per-opcode basis
using imm-hist.opcodes."<REGEX>" feature. RISCV backend respects the
immediate values provided in the configuration.