### PR TITLE
[snippy][cmake] Add missing dependency on tablegen target for LLVMSnippy lib

### DIFF
--- a/llvm/tools/llvm-snippy/lib/CMakeLists.txt
+++ b/llvm/tools/llvm-snippy/lib/CMakeLists.txt
@@ -59,6 +59,7 @@ add_llvm_library(LLVMSnippy
   ${LLVMSnippySources}
   DEPENDS
   intrinsics_gen
+  LLVMSnippyDriverOptionsTableGen
   LINK_LIBS PRIVATE
     $<BUILD_LOCAL_INTERFACE:LLVMSnippyGenerator>
   )


### PR DESCRIPTION
[snippy][cmake] Add missing dependency on tablegen target for LLVMSnippy lib

This leads to unpredictable build system races.