### PR TITLE
[snippy] Use APInts of xlen size when calculating offsets and addresses for rv32

### DIFF
--- a/llvm/tools/llvm-snippy/lib/Generator/Interpreter.cpp
+++ b/llvm/tools/llvm-snippy/lib/Generator/Interpreter.cpp
@@ -537,7 +537,8 @@ void Interpreter::discardTransaction() {
 
   Simulator->setPC(getPCBeforeTransaction());
   for (auto [Addr, Value] : getMemBeforeTransaction())
-    Simulator->writeMem(Addr, APInt(sizeof(Value) * CHAR_BIT, Value));
+    Simulator->writeMem(
+        Addr, APInt(sizeof(Value) * CHAR_BIT, Value, /* signed */ true));
   for (auto [RegID, Value] : getXRegsBeforeTransaction())
     Simulator->setGPR(RegID, Value);
   for (auto [RegID, Value] : getFRegsBeforeTransaction())


### PR DESCRIPTION
Use APInts of xlen size when calculating offsets and addresses for rv32

In some cases we have assertions from APInt:
Assertion `llvm::isUIntN(BitWidth, val) && "Value is not an N-bit unsigned value"'

This happens, because we use uint64_t for calculations and is some cases rely on
wrapping around zero. Instead of uint64_t we should use xlen-based type.