### PR TITLE
[snippy] Improve randomness of loop counter stride

### DIFF
--- a/llvm/tools/llvm-snippy/include/snippy/Config/Branchegram.h
+++ b/llvm/tools/llvm-snippy/include/snippy/Config/Branchegram.h
@@ -59,11 +59,14 @@ struct Branchegram final {
     // const char * instead of StringRef because we want to easily pass this to
     // functions that require const char*, such as mapOptional.
     static constexpr const char *InitRangeOptName = "random-init";
+    static constexpr const char *StrideRangeOptName = "random-stride";
     static constexpr const char *UseStackOptName = "place-on-stack";
 
     using OptRange = std::optional<NumericRange<unsigned>>;
-    // Range of values for loop counter initialization
+    // Range of values for loop counters initialization
     OptRange InitRange;
+    // Range of values for selecting stride for loop counters
+    OptRange StrideRange;
     std::optional<bool> UseStack;
   };
 
@@ -91,6 +94,10 @@ struct Branchegram final {
 
   bool isStackLoopCountersRequested() const {
     return LoopCounters.UseStack.has_value() && LoopCounters.UseStack.value();
+  }
+
+  bool isRandomCountersStrideRequested() const {
+    return LoopCounters.StrideRange.has_value();
   }
 
   unsigned getMaxLoopDepth() const { return MaxDepth.Loop; }

--- a/llvm/tools/llvm-snippy/include/snippy/Generator/LoopLatcherPass.h
+++ b/llvm/tools/llvm-snippy/include/snippy/Generator/LoopLatcherPass.h
@@ -41,7 +41,8 @@ private:
                                   ArrayRef<Register> ReservedRegs);
 
   bool NIterWarned = false;
-  bool LoopCounterWarned = false;
+  bool LoopCounterInitWarned = false;
+  bool LoopCounterStrideWarned = false;
 };
 
 } // namespace snippy

--- a/llvm/tools/llvm-snippy/include/snippy/Support/DiagnosticInfo.h
+++ b/llvm/tools/llvm-snippy/include/snippy/Support/DiagnosticInfo.h
@@ -32,6 +32,7 @@ namespace snippy {
   WARN_CASE(InconsistentOptions, "inconsistent-options")                       \
   WARN_CASE(LoopIterationNumber, "loop-iteration-number")                      \
   WARN_CASE(LoopCounterOutOfRange, "loop-counter-out-of-range")                \
+  WARN_CASE(LoopStrideOutOfRange, "loop-stride-out-of-range")                  \
   WARN_CASE(BurstMode, "burst-mode")                                           \
   WARN_CASE(InstructionCount, "instruction-count")                             \
   WARN_CASE(RegState, "register-state")                                        \

--- a/llvm/tools/llvm-snippy/include/snippy/Target/Target.h
+++ b/llvm/tools/llvm-snippy/include/snippy/Target/Target.h
@@ -495,9 +495,11 @@ public:
   virtual unsigned getInstrSize(const MachineInstr &Inst,
                                 LLVMState &State) const = 0;
 
-  struct LoopCounterInitResult {
-    std::optional<SnippyDiagnosticInfo> Diag;
+  struct LoopCounterInitResult final {
+    std::optional<SnippyDiagnosticInfo> InitValueDiag;
+    std::optional<SnippyDiagnosticInfo> StrideValueDiag;
     APInt MinCounterVal;
+    APInt StrideVal;
   };
 
   virtual LoopCounterInitResult
@@ -507,7 +509,7 @@ public:
 
   virtual LoopType getLoopType(MachineInstr &Branch) const = 0;
 
-  struct LoopCounterInsertionResult {
+  struct LoopCounterInsertionResult final {
     std::optional<SnippyDiagnosticInfo> Diag;
     unsigned NIter;
     APInt MinCounterVal;
@@ -517,7 +519,7 @@ public:
   insertLoopCounter(InstructionGenerationContext &IGC, MachineInstr &MI,
                     ArrayRef<Register> ReservedRegs, unsigned NIter,
                     RegToValueType &ExitingValues,
-                    unsigned RegCounterOffset) const = 0;
+                    const LoopCounterInitResult &CounterInitInfo) const = 0;
 
   virtual ~SnippyTarget();
 

--- a/llvm/tools/llvm-snippy/lib/Target/RISCV/RISCVGenerated.h
+++ b/llvm/tools/llvm-snippy/lib/Target/RISCV/RISCVGenerated.h
@@ -17,6 +17,8 @@
 #include "MCTargetDesc/RISCVMCTargetDesc.h"
 #include "snippy/Support/DiagnosticInfo.h"
 
+#include "llvm/Support/FormatVariadic.h"
+
 #include "RISCV.h"
 #include "RISCVInstrInfo.h"
 #include "RISCVRegisterInfo.h"
@@ -560,6 +562,68 @@ inline size_t getNumFields(unsigned Opcode) {
     return 8;
   default:
     llvm_unreachable("Invalid segment load/store instruction opcode");
+  }
+}
+
+inline size_t getImmSizeInBits(unsigned Opcode) {
+  switch (Opcode) {
+  case RISCV::ADDI:
+  case RISCV::ADDIW:
+  case RISCV::SLTI:
+  case RISCV::SLTIU:
+  case RISCV::XORI:
+  case RISCV::ORI:
+  case RISCV::ANDI:
+  case RISCV::SLLI:
+  case RISCV::SRLI:
+  case RISCV::SRAI:
+  case RISCV::FLD:
+  case RISCV::FSD:
+  case RISCV::FLW:
+  case RISCV::FSW:
+  case RISCV::LB:
+  case RISCV::LH:
+  case RISCV::LW:
+  case RISCV::LBU:
+  case RISCV::LHU:
+  case RISCV::SB:
+  case RISCV::SH:
+  case RISCV::SW:
+  case RISCV::JALR:
+  case RISCV::BEQ:
+  case RISCV::BNE:
+  case RISCV::BLT:
+  case RISCV::BLTU:
+  case RISCV::BGE:
+  case RISCV::BGEU:
+    return 12;
+  case RISCV::LUI:
+  case RISCV::AUIPC:
+  case RISCV::JAL:
+    return 20;
+  case RISCV::C_ADDI:
+  case RISCV::C_ADDIW:
+  case RISCV::C_ADDI16SP:
+  case RISCV::C_LI:
+  case RISCV::C_LUI:
+  case RISCV::C_SRLI:
+  case RISCV::C_SRAI:
+  case RISCV::C_ANDI:
+  case RISCV::C_NOP:
+    return 6;
+  case RISCV::C_J:
+  case RISCV::C_JAL:
+    return 11;
+  case RISCV::C_BEQZ:
+  case RISCV::C_BNEZ:
+  case RISCV::C_ADDI4SPN:
+    return 8;
+  default:
+    llvm_unreachable(llvm::formatv("Invalid opcode: {0}. There is no immediate "
+                                   "operand for such an instruction",
+                                   Opcode)
+                         .str()
+                         .data());
   }
 }
 

--- a/llvm/tools/llvm-snippy/lib/Target/X86/Target.cpp
+++ b/llvm/tools/llvm-snippy/lib/Target/X86/Target.cpp
@@ -369,11 +369,11 @@ public:
     reportUnimplementedError();
   }
 
-  LoopCounterInsertionResult
-  insertLoopCounter(InstructionGenerationContext &IGC, MachineInstr &Branch,
-                    ArrayRef<Register> ReservedRegs, unsigned NIter,
-                    RegToValueType &ExitingValues,
-                    unsigned RegCounterOffset) const override {
+  LoopCounterInsertionResult insertLoopCounter(
+      InstructionGenerationContext &IGC, MachineInstr &Branch,
+      ArrayRef<Register> ReservedRegs, unsigned NIter,
+      RegToValueType &ExitingValues,
+      const LoopCounterInitResult &CounterInitInfo) const override {
     reportUnimplementedError();
   }
 


### PR DESCRIPTION
This patch introduces loop counter stride randomization.
Example in .yaml config:

```yaml
branches:
  loop-counters:
    random-stride:
      enabled: <on/off> # optional
      min: 5 # optional
      max: 10 # optional
```
Something from [enabled, min, max] list must be specified, otherwise an error
occurs