### PR TITLE
[snippy][Config] Diagnose unknown YAML keys

### DIFF
--- a/llvm/test/tools/llvm-snippy/branches/rvc-and-reserved.yaml
+++ b/llvm/test/tools/llvm-snippy/branches/rvc-and-reserved.yaml
@@ -16,7 +16,7 @@ sections:
 histogram:
     - [BEQ, 1.0]
 
-branchegram:
+branches:
   loop-ratio: 1
 
 options:

--- a/llvm/test/tools/llvm-snippy/cl-options-error-toplevel.yaml
+++ b/llvm/test/tools/llvm-snippy/cl-options-error-toplevel.yaml
@@ -7,7 +7,7 @@ clueless-user-toplevel-option: check
 dump-mf: true
 unknown-option: [1, 2, 3]
 
-# CHECK-NOT: warning: unknown key 'options'
-# CHECK: cl-options-error-toplevel.yaml:7:1: warning: unknown key 'dump-mf'
-# CHECK: cl-options-error-toplevel.yaml:6:1: warning: unknown key 'clueless-user-toplevel-option'
-# CHECK: cl-options-error-toplevel.yaml:8:1: warning: unknown key 'unknown-option'
+# CHECK-NOT: error: unknown key 'options'
+# CHECK: cl-options-error-toplevel.yaml:7:1: error: unknown key 'dump-mf'
+# CHECK: cl-options-error-toplevel.yaml:6:1: error: unknown key 'clueless-user-toplevel-option'
+# CHECK: cl-options-error-toplevel.yaml:8:1: error: unknown key 'unknown-option'


### PR DESCRIPTION
[snippy][Config] Diagnose unknown YAML keys

This patch ensures that unknown keys in snippy configuration
are not warnings but hard errors. This was previously tricky
to do because Config is parsed several times:

- Once to only read options like mtriple e.t.c.
- The second time to actually fill the Config. This time
  options are completely ignored.