### PR TITLE
[snippy] excludeFromMemRegsForOpcode should return base regs

### DIFF
--- a/llvm/tools/llvm-snippy/include/snippy/Target/Target.h
+++ b/llvm/tools/llvm-snippy/include/snippy/Target/Target.h
@@ -458,7 +458,8 @@ public:
                             const MachineBasicBlock &MBB) const = 0;
 
   virtual std::vector<Register>
-  excludeFromMemRegsForOpcode(unsigned Opcode) const = 0;
+  excludeFromMemRegsForOpcode(unsigned Opcode,
+                              const MCRegisterInfo &RI) const = 0;
 
   // FIXME: basically, we should need only MCRegisterClass, but now
   // MCRegisterClass for RISCV does not fully express available regs.

--- a/llvm/tools/llvm-snippy/lib/Generator/GenerationUtils.cpp
+++ b/llvm/tools/llvm-snippy/lib/Generator/GenerationUtils.cpp
@@ -485,18 +485,21 @@ generateBaseRegs(InstructionGenerationContext &InstrGenCtx,
   auto &State = ProgCtx.getLLVMState();
   const auto &SnippyTgt = State.getSnippyTarget();
   const auto &InstrInfo = State.getInstrInfo();
+  const auto &RI = State.getRegInfo();
   // Compute set of registers compatible with all opcodes
   std::unordered_set<unsigned> Exclude;
   for (auto Opcode : Opcodes) {
-    copy(SnippyTgt.excludeFromMemRegsForOpcode(Opcode),
+    copy(SnippyTgt.excludeFromMemRegsForOpcode(Opcode, RI),
          std::inserter(Exclude, Exclude.begin()));
   }
   // Current implementation expects that each target has only one addr reg
   // class.
   const auto &AddrRegClass = SnippyTgt.getAddrRegClass();
   SmallVector<Register, 32> Include;
-  copy_if(AddrRegClass, std::back_inserter(Include),
-          [&](Register Reg) { return !Exclude.count(Reg); });
+  copy_if(AddrRegClass, std::back_inserter(Include), [&](Register Reg) {
+    return none_of(SnippyTgt.getPhysRegsFromUnit(Reg, RI),
+                   [&Exclude](auto R) { return Exclude.count(R); });
+  });
 
   // Normalize the number of addr registers to use. It's possible that we'll
   // re-use addr regs with different offset values.
@@ -540,7 +543,10 @@ generateBaseRegs(InstructionGenerationContext &InstrGenCtx,
   // destinations.
   auto AddrRegs = RP.getNAvailableRegisters(
       "for memory access burst", RegInfo, *AddrRegClass.MC, MBB, NumAddrs,
-      [&](Register R) { return Exclude.count(R); });
+      [&](Register R) {
+        return any_of(SnippyTgt.getPhysRegsFromUnit(R, RI),
+                      [&Exclude](auto Reg) { return Exclude.count(Reg); });
+      });
 
   for (auto Reg : AddrRegs)
     RP.addReserved(Reg, AccessMaskBit::W);

--- a/llvm/tools/llvm-snippy/lib/Target/X86/Target.cpp
+++ b/llvm/tools/llvm-snippy/lib/Target/X86/Target.cpp
@@ -439,7 +439,8 @@ public:
   }
 
   std::vector<Register>
-  excludeFromMemRegsForOpcode(unsigned Opcode) const override {
+  excludeFromMemRegsForOpcode(unsigned Opcode,
+                              const MachineRegisterInfo &RI) const override {
     reportUnimplementedError();
   }
 


### PR DESCRIPTION
[snippy] excludeFromMemRegsForOpcode should return base regs