### PR TITLE
[snippy] add getPhysRegsFromUnit to RegPoolWrapper

### DIFF
--- a/llvm/tools/llvm-snippy/include/snippy/Generator/RegisterPool.h
+++ b/llvm/tools/llvm-snippy/include/snippy/Generator/RegisterPool.h
@@ -256,16 +256,19 @@ public:
 
   void reset() { Pools.back() = RegPool{}; }
 
+  std::vector<Register> getPhysRegsFromUnit(Register RegUnit) const {
+    return SnippyTgt.getPhysRegsFromUnit(RegUnit, RegInfo);
+  }
+
   template <typename... ArgsTys>
   bool isReserved(unsigned Reg, ArgsTys &&...Args) const {
     // Only physical registers can be reserved.
     // Therefore, we must identify the physical register
     // of this alias and check it.
     return any_of(Pools, [&](auto &Pool) {
-      return any_of(
-          SnippyTgt.getPhysRegsFromUnit(Reg, RegInfo), [&](auto &PhReg) {
-            return Pool.isReserved(PhReg, std::forward<ArgsTys>(Args)...);
-          });
+      return any_of(getPhysRegsFromUnit(Reg), [&](auto PhReg) {
+        return Pool.isReserved(PhReg, std::forward<ArgsTys>(Args)...);
+      });
     });
   }
 
@@ -280,7 +283,7 @@ public:
                             << "\nBefore reservation: ",
                      dump()));
 
-    auto PhRegs = SnippyTgt.getPhysRegsFromUnit(Reg, RegInfo);
+    auto PhRegs = getPhysRegsFromUnit(Reg);
     for (auto &&PhReg : PhRegs)
       Pools.back().addReserved(PhReg, std::forward<ArgsTys>(Args)...);
 

--- a/llvm/tools/llvm-snippy/lib/Generator/RegisterGenerator.cpp
+++ b/llvm/tools/llvm-snippy/lib/Generator/RegisterGenerator.cpp
@@ -46,9 +46,11 @@ static bool regIsReserved(unsigned RegIdx, ArrayRef<Register> Exclude,
                           const MCRegisterClass &RC,
                           ArrayRef<Register> Include) {
   Register Reg = getRegFromIdx(RC, Include, RegIdx);
+  auto PhysRegs = RP.getPhysRegsFromUnit(Reg);
   return RP.isReserved(Reg, MBB, Mask) ||
-         any_of(Exclude,
-                [Reg](unsigned ExcludeReg) { return ExcludeReg == Reg; });
+         any_of(Exclude, [&PhysRegs](unsigned ExcludeReg) {
+           return is_contained(PhysRegs, ExcludeReg);
+         });
 }
 
 unsigned RegTranslatorHandle::getRegFromStr(


### PR DESCRIPTION
[snippy] add getPhysRegsFromUnit to RegPoolWrapper
    
We need a way to get base registers from the superreg in reg gen plugin