### PR TITLE
[snippy][minor]: Fix the method signature for X86-target implementation

### DIFF
--- a/llvm/tools/llvm-snippy/lib/Target/X86/Target.cpp
+++ b/llvm/tools/llvm-snippy/lib/Target/X86/Target.cpp
@@ -440,7 +440,7 @@ public:
 
   std::vector<Register>
   excludeFromMemRegsForOpcode(unsigned Opcode,
-                              const MachineRegisterInfo &RI) const override {
+                              const MCRegisterInfo &RI) const override {
     reportUnimplementedError();
   }
 


### PR DESCRIPTION
[snippy][minor]: Fix the method signature for X86-target implementation