### PR TITLE
[snippy] Check that config addresses fit in address space size

### DIFF
--- a/llvm/test/tools/llvm-snippy/rv32-almost-large-section-address.yaml
+++ b/llvm/test/tools/llvm-snippy/rv32-almost-large-section-address.yaml
@@ -1,0 +1,22 @@
+# RUN: llvm-snippy -model-plugin=None %s |& FileCheck %s
+
+options:
+  mtriple: riscv32-unknown-elf
+  num-instrs: 10
+
+sections:
+    - name:      text
+      VMA:       0x11111111
+      SIZE:      0x10000000
+      LMA:       0x11111111
+      ACCESS:    rx
+    - name:      data
+      VMA:       0x90000000
+      SIZE:      0x40000
+      LMA:       0x90000000
+      ACCESS:    rw
+
+histogram:
+  - [BLT, 1.0]
+
+# CHECK-NOT: 'VMA' is too large. Selected target supports only 32 bit addresses

--- a/llvm/test/tools/llvm-snippy/rv32-large-acces-ranges-end.yaml
+++ b/llvm/test/tools/llvm-snippy/rv32-large-acces-ranges-end.yaml
@@ -1,0 +1,25 @@
+# RUN: not llvm-snippy -model-plugin=None %s |& FileCheck %s
+
+options:
+  mtriple: riscv32-unknown-elf
+  num-instrs: 10
+
+include:
+  - Inputs/sections.yaml
+
+histogram:
+  - [LW, 1.0]
+
+access-ranges:
+  - start: 0x40000000
+    size: 0xffffffff
+    stride: 8
+    first-offset: 0
+    last-offset: 0
+  - start: 0x40001000
+    size: 0xffffffff
+    stride: 8
+    first-offset: 0
+    last-offset: 0
+
+# CHECK: error: 'size' is too large. Selected target supports only 32 bit addresses. 'start' + 'size' does not fit into 32 bits

--- a/llvm/test/tools/llvm-snippy/rv32-large-acces-ranges-start.yaml
+++ b/llvm/test/tools/llvm-snippy/rv32-large-acces-ranges-start.yaml
@@ -1,0 +1,25 @@
+# RUN: not llvm-snippy -model-plugin=None %s |& FileCheck %s
+
+options:
+  mtriple: riscv32-unknown-elf
+  num-instrs: 10
+
+include:
+  - Inputs/sections.yaml
+
+histogram:
+  - [LW, 1.0]
+
+access-ranges:
+  - start: 0x400000000
+    size: 64
+    stride: 8
+    first-offset: 0
+    last-offset: 0
+  - start: 0x400001000
+    size: 8
+    stride: 8
+    first-offset: 0
+    last-offset: 0
+
+# CHECK: error: 'start' is too large. Selected target supports only 32 bit addresses

--- a/llvm/test/tools/llvm-snippy/rv32-large-access-address-access-size.yaml
+++ b/llvm/test/tools/llvm-snippy/rv32-large-access-address-access-size.yaml
@@ -1,0 +1,27 @@
+# RUN: not llvm-snippy -model-plugin=None %s |& FileCheck %s
+
+options:
+  mtriple: riscv32-unknown-elf
+  num-instrs: 10
+
+include:
+  - Inputs/sections.yaml
+
+histogram:
+  - [LW, 1.0]
+
+access-addresses:
+  - ordered: true
+    plain:
+      - addr: 0x80002001
+      - addr: 0x80000000
+  - ordered: true
+    plain:
+      - addr: 0x80001234
+        access-size: 0xffffffffff
+      - addr: 0x80000000
+  - ordered: true
+    plain:
+      - addr: 0x80000300
+
+# CHECK: error: 'access-size' is too large. Selected target supports only 32 bit addresses

--- a/llvm/test/tools/llvm-snippy/rv32-large-access-address-addr.yaml
+++ b/llvm/test/tools/llvm-snippy/rv32-large-access-address-addr.yaml
@@ -1,0 +1,26 @@
+# RUN: not llvm-snippy -model-plugin=None %s |& FileCheck %s
+
+options:
+  mtriple: riscv32-unknown-elf
+  num-instrs: 10
+
+include:
+  - Inputs/sections.yaml
+
+histogram:
+  - [LW, 1.0]
+
+access-addresses:
+  - ordered: true
+    plain:
+      - addr: 0x80002001
+      - addr: 0x80000000
+  - ordered: true
+    plain:
+      - addr: 0x80001234
+      - addr: 0x800000000
+  - ordered: true
+    plain:
+      - addr: 0x80000300
+
+# CHECK: error: 'addr' is too large. Selected target supports only 32 bit addresses

--- a/llvm/test/tools/llvm-snippy/rv32-large-access-evictions-fixed.yaml
+++ b/llvm/test/tools/llvm-snippy/rv32-large-access-evictions-fixed.yaml
@@ -1,0 +1,17 @@
+# RUN: not llvm-snippy -model-plugin=None %s |& FileCheck %s
+
+options:
+  mtriple: riscv32-unknown-elf
+  num-instrs: 10
+
+include:
+  - Inputs/sections.yaml
+
+histogram:
+  - [LW, 1.0]
+
+access-evictions:
+    - mask:  0x40000000
+      fixed: 0x10000000f
+
+# CHECK: error: 'fixed' is too large. Selected target supports only 32 bit addresses

--- a/llvm/test/tools/llvm-snippy/rv32-large-access-evictions-mask.yaml
+++ b/llvm/test/tools/llvm-snippy/rv32-large-access-evictions-mask.yaml
@@ -1,0 +1,17 @@
+# RUN: not llvm-snippy -model-plugin=None %s |& FileCheck %s
+
+options:
+  mtriple: riscv32-unknown-elf
+  num-instrs: 10
+
+include:
+  - Inputs/sections.yaml
+
+histogram:
+  - [LW, 1.0]
+
+access-evictions:
+    - mask:  0x400000000
+      fixed: 0x000000ff
+
+# CHECK: error: 'mask' is too large. Selected target supports only 32 bit addresses

--- a/llvm/test/tools/llvm-snippy/rv32-large-section-address.yaml
+++ b/llvm/test/tools/llvm-snippy/rv32-large-section-address.yaml
@@ -1,0 +1,22 @@
+# RUN: not llvm-snippy -model-plugin=None %s |& FileCheck %s
+
+options:
+  mtriple: riscv32-unknown-elf
+  num-instrs: 10
+
+sections:
+    - name:      text
+      VMA:       0x80000000
+      SIZE:      0x10000000
+      LMA:       0x80000000
+      ACCESS:    rx
+    - name:      data
+      VMA:       0x900000000
+      SIZE:      0x40000
+      LMA:       0x900000000
+      ACCESS:    rw
+
+histogram:
+  - [BLT, 1.0]
+
+# CHECK: error: 'VMA' is too large. Selected target supports only 32 bit addresses

--- a/llvm/tools/llvm-snippy/include/snippy/Config/MemoryScheme.h
+++ b/llvm/tools/llvm-snippy/include/snippy/Config/MemoryScheme.h
@@ -740,7 +740,7 @@ LLVM_SNIPPY_YAML_IS_SEQUENCE_ELEMENT(snippy::MemoryAccessesGroup,
                                      /* not flow */ false);
 
 LLVM_SNIPPY_YAML_DECLARE_SCALAR_TRAITS_NG(snippy::AccMask);
-LLVM_SNIPPY_YAML_DECLARE_MAPPING_TRAITS(snippy::SectionDesc);
+LLVM_SNIPPY_YAML_DECLARE_MAPPING_TRAITS_WITH_VALIDATE(snippy::SectionDesc);
 LLVM_SNIPPY_YAML_DECLARE_SEQUENCE_TRAITS(snippy::SectionsDescriptions,
                                          snippy::SectionDesc);
 


### PR DESCRIPTION
This commit adds a check to validate addresses in the configuration file, ensuring they do not exceed the address space size.