### PR TITLE
[snippy][RISCV] Get rid of unnecessary copying of MCRegisterInfo

### DIFF
--- a/llvm/tools/llvm-snippy/lib/Target/RISCV/Target.cpp
+++ b/llvm/tools/llvm-snippy/lib/Target/RISCV/Target.cpp
@@ -1326,8 +1326,8 @@ public:
                       const MCRegisterInfo &RI) const override {
     if (RegClassID == RISCV::VMV0RegClassID)
       return false;
-    auto RC = RI.getRegClass(RegClassID);
-    return std::all_of(RC.begin(), RC.end(), [this, RI](unsigned Reg) {
+    const auto &RC = RI.getRegClass(RegClassID);
+    return std::all_of(RC.begin(), RC.end(), [this, &RI](unsigned Reg) {
       return !isMultipleReg(Reg, RI);
     });
   }


### PR DESCRIPTION
[snippy][RISCV] Get rid of unnecessary copying of MCRegisterInfo

This would result in snippy spending about %40 of the total runtime
in the std::vector<unsigned> copy constructor.