### PR TITLE
[snippy] Fix all target instructions non-creation with valuegram policy

### DIFF
--- a/llvm/test/tools/llvm-snippy/initialization/apply-valuegram-each-instr/hints-generation.yaml
+++ b/llvm/test/tools/llvm-snippy/initialization/apply-valuegram-each-instr/hints-generation.yaml
@@ -1,0 +1,39 @@
+# COM: This test checks the correctness of the hint insertion generation behavior 
+# COM: with the valuegram policy. Hints can only be inserted between sets of instructions 
+# COM: (target and support, for generating values ​​in registers).
+
+# RUN: llvm-snippy %s \
+# RUN:    -model-plugin=None \
+# RUN:    -generate-insertion-point-hints \
+# RUN:    -valuegram-operands-regs=%S/Inputs/histograms.yaml \
+# RUN: |& FileCheck %s
+
+options:
+  mtriple: "riscv64-linux-gnu"
+  num-instrs: 100
+  dump-mf: on
+
+sections:
+    - no:        0
+      VMA:       0x2000000
+      SIZE:      0x1000000
+      LMA:       0x2000000
+      ACCESS:    r
+    - no:        1
+      VMA:       0x80000000
+      SIZE:      0x400000
+      LMA:       0x80000000
+      ACCESS:    rx
+    - no:        2
+      VMA:       0x80600000
+      SIZE:      0x0400000
+      LMA:       0x80600000
+      ACCESS:    rw
+
+histogram:
+    - [ADD, 1.0]
+    - [SUB, 1.0]
+    - [LW, 1.0]
+    - [SW, 2.0]
+
+# CHECK-COUNT-102: $x0 = ADDI $x0, 0

--- a/llvm/tools/llvm-snippy/include/snippy/Generator/OperandsReinitialiazationPolicy.h
+++ b/llvm/tools/llvm-snippy/include/snippy/Generator/OperandsReinitialiazationPolicy.h
@@ -64,7 +64,7 @@ public:
   void initialize(InstructionGenerationContext &InstrGenCtx,
                   const RequestLimit &Limit);
 
-  bool isInseparableBundle() const { return true; }
+  bool isInseparableBundle() const { return false; }
 
   void print(raw_ostream &OS) const { OS << "Valuegram Generation Policy\n"; }
 

--- a/llvm/tools/llvm-snippy/include/snippy/Generator/Policy.h
+++ b/llvm/tools/llvm-snippy/include/snippy/Generator/Policy.h
@@ -323,6 +323,9 @@ private:
 struct InstructionRequest final {
   unsigned Opcode;
   std::vector<PreselectedOpInfo> Preselected;
+
+  // TODO: Replace this flag with MDNode (Metadata Node)
+  bool IsSupport = false;
 };
 
 namespace detail {
@@ -402,14 +405,18 @@ public:
 class FinalInstPolicy final : public detail::EmptyFinalizeMixin {
   unsigned Opcode;
   const CommonPolicyConfig *Cfg;
+  bool WasUsed = false;
 
 public:
   FinalInstPolicy(const CommonPolicyConfig &Cfg, unsigned Opc)
       : Opcode(Opc), Cfg(&Cfg) {}
 
-  bool isInseparableBundle() const { return false; }
+  bool isInseparableBundle() const { return true; }
 
-  std::optional<InstructionRequest> next() const {
+  std::optional<InstructionRequest> next() {
+    if (WasUsed)
+      return std::nullopt;
+    WasUsed = true;
     return InstructionRequest{Opcode, {}};
   }
 

--- a/llvm/tools/llvm-snippy/lib/Generator/OperandsReinitializationPolicy.cpp
+++ b/llvm/tools/llvm-snippy/lib/Generator/OperandsReinitializationPolicy.cpp
@@ -220,11 +220,11 @@ ValuegramGenPolicy::generateRegInit(InstructionGenerationContext &InstrGenCtx,
         SmallVector<MCInst> InstrsForWrite;
         Tgt.generateWriteValueSeq(InstrGenCtx, *ValueToWrite,
                                   SimpleReg.asMCReg(), InstrsForWrite);
-        llvm::transform(InstrsForWrite, std::back_inserter(InitInstrs),
-                        [&](const auto &I) {
-                          return InstructionRequest{I.getOpcode(),
-                                                    getPreselectedForInstr(I)};
-                        });
+        llvm::transform(
+            InstrsForWrite, std::back_inserter(InitInstrs), [&](const auto &I) {
+              return InstructionRequest{
+                  I.getOpcode(), getPreselectedForInstr(I), /*IsSupport=*/true};
+            });
       });
   return InitInstrs;
 }


### PR DESCRIPTION
\[snippy\] Fix all target instructions non-creation with valuegram policy

The Valuegram-generated instructions for register value creation were not marked as supported. As a result, they were treated as main instructions, which prevented snippy from generating all intended target instructions.