### PR TITLE
[snippy] Add ReadFCSR, WriteFCSRImm, SwapFCSRImm pseudoinstructions

### DIFF
--- a/llvm/lib/Target/RISCV/RISCVInstrInfo.td
+++ b/llvm/lib/Target/RISCV/RISCVInstrInfo.td
@@ -1803,6 +1803,10 @@ def WriteFFLAGS : WriteSysReg<SysRegFFLAGS, [FFLAGS]>;
 // Needed only for llvm-snippy.
 def WriteFFLAGSImm : WriteSysRegImm<SysRegFFLAGS, [FFLAGS]>;
 def SwapFFLAGSImm : SwapSysRegImm<SysRegFFLAGS, [FFLAGS]>;
+
+def ReadFCSR : ReadSysReg<SysRegFCSR, [FRM, FFLAGS]>;
+def WriteFCSRImm : WriteSysRegImm<SysRegFCSR, [FRM, FFLAGS]>;
+def SwapFCSRImm : SwapSysRegImm<SysRegFCSR, [FRM, FFLAGS]>;
 }
 /// Other pseudo-instructions
 

--- a/llvm/test/tools/llvm-snippy/floating-point/float-read-write-fcsr-imm-hist.yaml
+++ b/llvm/test/tools/llvm-snippy/floating-point/float-read-write-fcsr-imm-hist.yaml
@@ -1,0 +1,25 @@
+# RUN: llvm-snippy %s -mattr +f,-d -model-plugin None -o %t
+# RUN: llvm-objdump %t.elf -d |& FileCheck %s -dump-input fail
+# RUN: llvm-snippy %s -mattr +d -model-plugin None -o %t
+# RUN: llvm-objdump %t.elf -d |& FileCheck %s -dump-input fail
+include:
+  - ../Inputs/sections.yaml
+options:
+  march: riscv64-unknown-elf
+  mcpu: generic-rv64
+  num-instrs: 2000
+histogram:
+  - [WriteFCSRImm, 1.0]
+  - [SwapFCSRImm, 1.0]
+  - [ReadFCSR, 0.2]
+imm-hist:
+  opcodes:
+    - "WriteFCSRImm|SwapFCSRImm": uniform
+
+
+# CHECK-DAG: csrwi fcsr, {{([[:digit:]][[:digit:]])|([[:digit:]])}}
+# CHECK-DAG: frcsr {{[sat][[:digit:]]+}}
+# CHECK-DAG: csrrwi {{[sat][[:digit:]]+}}, fcsr, {{[[:digit:]][[:digit:]]?}}
+
+# CHECK-NOT: csrwi fcsr, {{(3[2-9])|([4-9][[:digit:]])|([[:digit:]][[:digit:]][[:digit:]]+)}}
+# CHECK-NOT: csrwi {{[sat][[:digit:]]+}}, fcsr, {{(3[2-9])|([4-9][[:digit:]])|([[:digit:]][[:digit:]][[:digit:]]+)}}

--- a/llvm/tools/llvm-snippy/lib/Target/RISCV/Target.cpp
+++ b/llvm/tools/llvm-snippy/lib/Target/RISCV/Target.cpp
@@ -1108,6 +1108,10 @@ public:
     // Allows setting rounding mode when combined with per-opcode `imm-hist`.
     case RISCV::WriteFRMImm:
     case RISCV::SwapFRMImm:
+
+    case RISCV::ReadFCSR:
+    case RISCV::WriteFCSRImm:
+    case RISCV::SwapFCSRImm:
       return true;
     default:
       return false;


### PR DESCRIPTION
This patch adds several pseudoinstructions for working with FCSR:

- `ReadFCSR`
- `WriteFCSRImm`
- `SwapFCSRImm`