### PR TITLE
[snippy] Avoid copying MCRegisterInfo (take 2)

### DIFF
--- a/llvm/tools/llvm-snippy/lib/Generator/Generation.cpp
+++ b/llvm/tools/llvm-snippy/lib/Generator/Generation.cpp
@@ -428,7 +428,7 @@ void controlNaNPropagation(
         return (MI.getNumDefs() == 1) && hasFRegDestination(MI, Tgt);
       });
 
-  auto RI = ProgCtx.getLLVMState().getRegInfo();
+  const auto &RI = ProgCtx.getLLVMState().getRegInfo();
   // Here we add register classes whose registers will be unnaned
   SmallPtrSet<const MCRegisterClass *, 3> RegClassesToUnNaN;
   llvm::for_each(Filtered, [&](auto &MI) {


### PR DESCRIPTION
[snippy] Avoid copying MCRegisterInfo (take 2)

Copying MCRegisterInfo is really expensive and snippy spends about ~15%
runtime in just this copy constructor.