### PR TITLE
[snippy] Get rid of unnecessary allocations

### DIFF
--- a/llvm/tools/llvm-snippy/include/snippy/Target/Target.h
+++ b/llvm/tools/llvm-snippy/include/snippy/Target/Target.h
@@ -352,8 +352,9 @@ public:
   virtual Register getFirstPhysReg(Register Reg,
                                    const MCRegisterInfo &RI) const = 0;
 
-  virtual std::vector<Register>
-  getPhysRegsFromUnit(Register RegUnit, const MCRegisterInfo &RI) const = 0;
+  virtual void
+  getPhysRegsFromUnit(Register RegUnit, const MCRegisterInfo &RI,
+                      SmallVectorImpl<Register> &OutPhysRegs) const = 0;
 
   // This function is different from getPhysRegsFromUnit in that
   // it returns physical registers without overlaps.
@@ -361,9 +362,9 @@ public:
   // 2. If RegUnit is part of a physical register, we will return that part.
   // 3. Otherwise, we will return the physical register referenced by this
   // alias.
-  virtual std::vector<Register>
-  getPhysRegsWithoutOverlaps(Register RegUnit,
-                             const MCRegisterInfo &RI) const = 0;
+  virtual void
+  getPhysRegsWithoutOverlaps(Register RegUnit, const MCRegisterInfo &RI,
+                             SmallVectorImpl<Register> &OutPhysRegs) const = 0;
 
   virtual unsigned getMaxBranchDstMod(unsigned Opcode) const = 0;
 
@@ -457,9 +458,9 @@ public:
   getAccessSizeAndAlignment(SnippyProgramContext &ProgCtx, unsigned Opcode,
                             const MachineBasicBlock &MBB) const = 0;
 
-  virtual std::vector<Register>
-  excludeFromMemRegsForOpcode(unsigned Opcode,
-                              const MCRegisterInfo &RI) const = 0;
+  virtual void
+  excludeFromMemRegsForOpcode(unsigned Opcode, const MCRegisterInfo &RI,
+                              SmallVectorImpl<Register> &Regs) const = 0;
 
   // FIXME: basically, we should need only MCRegisterClass, but now
   // MCRegisterClass for RISCV does not fully express available regs.

--- a/llvm/tools/llvm-snippy/lib/Config/Config.cpp
+++ b/llvm/tools/llvm-snippy/lib/Config/Config.cpp
@@ -361,10 +361,11 @@ static void parseReservedRegistersOption(RegPoolWrapper &RP,
       snippy::fatal(formatv("Illegal register name {0}"
                             " is specified in --reserved-regs-list",
                             RegName));
-    llvm::for_each(Tgt.getPhysRegsFromUnit(Reg.value(), RI),
-                   [&RP](auto SimpleReg) {
-                     RP.addReserved(SimpleReg, AccessMaskBit::GRW);
-                   });
+    SmallVector<Register> PhysRegs;
+    Tgt.getPhysRegsFromUnit(Reg.value(), RI, PhysRegs);
+    llvm::for_each(PhysRegs, [&RP](auto SimpleReg) {
+      RP.addReserved(SimpleReg, AccessMaskBit::GRW);
+    });
     DEBUG_WITH_TYPE("snippy-regpool",
                     (dbgs() << "Reserved with option:\n", RP.print(dbgs())));
   }

--- a/llvm/tools/llvm-snippy/lib/Generator/RegisterGenerator.cpp
+++ b/llvm/tools/llvm-snippy/lib/Generator/RegisterGenerator.cpp
@@ -30,7 +30,8 @@ regUnitIsReserved(unsigned RegUnitIdx, const SnippyTarget &SnippyTgt,
                   AccessMaskBit Mask, const MCRegisterClass &RC,
                   ArrayRef<Register> Include) {
   auto RegUnit = getRegFromIdx(RC, Include, RegUnitIdx);
-  auto RegsInUnit = SnippyTgt.getPhysRegsFromUnit(RegUnit, RI);
+  SmallVector<Register> RegsInUnit;
+  SnippyTgt.getPhysRegsFromUnit(RegUnit, RI, RegsInUnit);
   if (any_of(RegsInUnit, [&RP, &MBB, Mask](unsigned Reg) {
         return RP.isReserved(Reg, MBB, Mask);
       }))
@@ -46,7 +47,8 @@ static bool regIsReserved(unsigned RegIdx, ArrayRef<Register> Exclude,
                           const MCRegisterClass &RC,
                           ArrayRef<Register> Include) {
   Register Reg = getRegFromIdx(RC, Include, RegIdx);
-  auto PhysRegs = RP.getPhysRegsFromUnit(Reg);
+  SmallVector<Register> PhysRegs;
+  RP.getPhysRegsFromUnit(Reg, PhysRegs);
   return RP.isReserved(Reg, MBB, Mask) ||
          any_of(Exclude, [&PhysRegs](unsigned ExcludeReg) {
            return is_contained(PhysRegs, ExcludeReg);

--- a/llvm/tools/llvm-snippy/lib/Target/X86/Target.cpp
+++ b/llvm/tools/llvm-snippy/lib/Target/X86/Target.cpp
@@ -250,15 +250,15 @@ public:
     reportUnimplementedError();
   }
 
-  std::vector<Register>
-  getPhysRegsFromUnit(Register RegUnit,
-                      const MCRegisterInfo &RI) const override {
+  void
+  getPhysRegsFromUnit(Register RegUnit, const MCRegisterInfo &RI,
+                      SmallVectorImpl<Register> &OutPhysRegs) const override {
     reportUnimplementedError();
   }
 
-  std::vector<Register>
-  getPhysRegsWithoutOverlaps(Register RegUnit,
-                             const MCRegisterInfo &RI) const override {
+  void getPhysRegsWithoutOverlaps(
+      Register RegUnit, const MCRegisterInfo &RI,
+      SmallVectorImpl<Register> &OutPhysRegs) const override {
     reportUnimplementedError();
   }
 
@@ -438,9 +438,9 @@ public:
     reportUnimplementedError();
   }
 
-  std::vector<Register>
-  excludeFromMemRegsForOpcode(unsigned Opcode,
-                              const MCRegisterInfo &RI) const override {
+  void
+  excludeFromMemRegsForOpcode(unsigned Opcode, const MCRegisterInfo &RI,
+                              SmallVectorImpl<Register> &Regs) const override {
     reportUnimplementedError();
   }
 


### PR DESCRIPTION
[snippy] Get rid of unnecessary allocations

Splitting units to physical registers is very frequently
used in register generation/selection and the overhead of
allocating a new `std::vector` for each call there is too much.
Just switching to `SmallVector` in the signature speeds up
the generation by ~30%.