### PR TITLE
[snippy] Avoid calling getSubtargetImpl for `Function`

### DIFF
--- a/llvm/tools/llvm-snippy/include/snippy/Generator/LLVMState.h
+++ b/llvm/tools/llvm-snippy/include/snippy/Generator/LLVMState.h
@@ -198,9 +198,8 @@ public:
   }
 
   template <typename SubtargetType>
-  const SubtargetType &getSubtarget(const MachineFunction &Fn) const {
-    return static_cast<const SubtargetType &>(
-        getSubtargetImpl(Fn.getFunction()));
+  static const SubtargetType &getSubtarget(const MachineFunction &Fn) {
+    return static_cast<const SubtargetType &>(Fn.getSubtarget());
   }
 
   auto &getMCContext() {

--- a/llvm/tools/llvm-snippy/include/snippy/Generator/Policy.h
+++ b/llvm/tools/llvm-snippy/include/snippy/Generator/Policy.h
@@ -298,11 +298,11 @@ public:
   auto &getRegPool() { return RPS.getCurrent(); }
 
   const TargetSubtargetInfo &getSubtargetImpl() const {
-    return getLLVMStateImpl().getSubtargetImpl(MBB.getParent()->getFunction());
+    return MBB.getParent()->getSubtarget();
   }
 
   template <typename SubtargetType> const SubtargetType &getSubtarget() const {
-    return getLLVMStateImpl().getSubtarget<SubtargetType>(*MBB.getParent());
+    return static_cast<const SubtargetType &>(getSubtargetImpl());
   }
 
   IAPIntSampler &

--- a/llvm/tools/llvm-snippy/lib/BlockGenPlanningPass.cpp
+++ b/llvm/tools/llvm-snippy/lib/BlockGenPlanningPass.cpp
@@ -701,8 +701,8 @@ static void setSizeForLoopBlock(planning::FunctionRequest &FunReq,
     BlockRange.Min =
         (PCDist.Min.value() > FilledSize) ? PCDist.Min.value() - FilledSize : 0;
 
-  auto InstrsSizes = SnpTgt.getPossibleInstrsSize(
-      State.getSubtargetImpl(SelectedMBB.getParent()->getFunction()));
+  auto InstrsSizes =
+      SnpTgt.getPossibleInstrsSize(SelectedMBB.getParent()->getSubtarget());
   assert(InstrsSizes.size() > 0 &&
          "Target must have at least one variant of instruction size");
   auto MinInstrSize = *InstrsSizes.begin();

--- a/llvm/tools/llvm-snippy/lib/Generator/GenerationUtils.cpp
+++ b/llvm/tools/llvm-snippy/lib/Generator/GenerationUtils.cpp
@@ -425,8 +425,8 @@ generateBaseRegs(InstructionGenerationContext &InstrGenCtx,
   if (NumAvailRegs == 0)
     snippy::fatal(
         "No available registers to generate addresses for the burst group.");
-  auto &Fn = InstrGenCtx.MBB.getParent()->getFunction();
-  const auto &RegInfo = *State.getSubtargetImpl(Fn).getRegisterInfo();
+  const auto *MF = InstrGenCtx.MBB.getParent();
+  const auto &RegInfo = *MF->getSubtarget().getRegisterInfo();
   // Get number of def and addr regs to use in the burst group. These values
   // can be bigger than the number of available registers.
   auto NumDefs = countDefsHavingRC(Opcodes, RegInfo, AddrRegClass, InstrInfo);

--- a/llvm/tools/llvm-snippy/lib/PostGenVerifierPass.cpp
+++ b/llvm/tools/llvm-snippy/lib/PostGenVerifierPass.cpp
@@ -268,10 +268,8 @@ static VerificationStatus verifyBBWithSizeLimit(
                              });
 
   const auto &SnippyTgt = State.getSnippyTarget();
-  unsigned MinInstrSize = *SnippyTgt
-                               .getPossibleInstrsSize(State.getSubtargetImpl(
-                                   MBB.getParent()->getFunction()))
-                               .begin();
+  unsigned MinInstrSize =
+      *SnippyTgt.getPossibleInstrsSize(MBB.getParent()->getSubtarget()).begin();
   if (Planned > Count && Planned - Count < MinInstrSize) {
     outs() << printMBBReference(MBB) << " :  size -- " << Count
            << ", planned -- " << Planned << "\n";


### PR DESCRIPTION
[snippy] Avoid calling getSubtargetImpl for `Function`

`LLVMTargetMachine::getSubtargetImpl` is quite expensive to call and
currently snippy spends around 10% in just getSubtargetImpl. This can
easily be avoided by just looking up the TargetSubtargetInfo from the
MachineFunction.