### PR TITLE
[snippy] Consecutive loops diagnostic

### DIFF
--- a/llvm/test/tools/llvm-snippy/branches/consecutive-loops-unconditional-branch-all.yaml
+++ b/llvm/test/tools/llvm-snippy/branches/consecutive-loops-unconditional-branch-all.yaml
@@ -1,0 +1,25 @@
+# RUN: not llvm-snippy %s -mtriple=riscv64-linux-gnu -num-instrs=100 \
+# RUN:     -mattr=+c -model-plugin None
+
+branches:
+  consecutive-loops: all
+  loop-ratio: 1
+  max-depth:
+    loop: 1
+
+sections:
+- ACCESS: rx
+  LMA: 0x80040000
+  SIZE: 0x40000
+  VMA: 0x80040000
+  name: 1
+- ACCESS: rw
+  LMA: 0x80080000
+  SIZE: 0x1000
+  VMA: 0x80080000
+  name: 2
+
+histogram:
+  - [C_J, 1.0]
+
+# CHECK: error: Consecutive loops are not supported with unconditional branches.

--- a/llvm/test/tools/llvm-snippy/branches/consecutive-loops-unconditional-branch.yaml
+++ b/llvm/test/tools/llvm-snippy/branches/consecutive-loops-unconditional-branch.yaml
@@ -1,0 +1,25 @@
+# RUN: not llvm-snippy %s -mtriple=riscv64-linux-gnu -num-instrs=100 \
+# RUN:     -mattr=+c -model-plugin None
+
+branches:
+  consecutive-loops: 2
+  loop-ratio: 1
+  max-depth:
+    loop: 1
+
+sections:
+- ACCESS: rx
+  LMA: 0x80040000
+  SIZE: 0x40000
+  VMA: 0x80040000
+  name: 1
+- ACCESS: rw
+  LMA: 0x80080000
+  SIZE: 0x1000
+  VMA: 0x80080000
+  name: 2
+
+histogram:
+  - [C_J, 1.0]
+
+# CHECK: error: Consecutive loops are not supported with unconditional branches.

--- a/llvm/test/tools/llvm-snippy/branches/disabled-consecutive-loops-unconditional-branch.yaml
+++ b/llvm/test/tools/llvm-snippy/branches/disabled-consecutive-loops-unconditional-branch.yaml
@@ -1,0 +1,25 @@
+# RUN: llvm-snippy %s -mtriple=riscv64-linux-gnu -num-instrs=100 \
+# RUN:     -mattr=+c -model-plugin None
+
+branches:
+  consecutive-loops: 0
+  loop-ratio: 1
+  max-depth:
+    loop: 1
+
+sections:
+- ACCESS: rx
+  LMA: 0x80040000
+  SIZE: 0x40000
+  VMA: 0x80040000
+  name: 1
+- ACCESS: rw
+  LMA: 0x80080000
+  SIZE: 0x1000
+  VMA: 0x80080000
+  name: 2
+
+histogram:
+  - [C_J, 1.0]
+
+# CHECK-NOT: error: Consecutive loops are not supported with unconditional branches.

--- a/llvm/tools/llvm-snippy/include/snippy/Config/Config.h
+++ b/llvm/tools/llvm-snippy/include/snippy/Config/Config.h
@@ -353,6 +353,10 @@ public:
     return Histogram.hasCFInstrs(OpCC);
   }
 
+  bool hasUncondBranches(const OpcodeCache &OpCC) const {
+    return Histogram.hasUncondBranches(OpCC);
+  }
+
   auto &getTrackCfg() const { return CommonPolicyCfg->TrackCfg; }
 
   bool hasTrackingMode() const {

--- a/llvm/tools/llvm-snippy/include/snippy/Config/OpcodeHistogram.h
+++ b/llvm/tools/llvm-snippy/include/snippy/Config/OpcodeHistogram.h
@@ -80,6 +80,13 @@ public:
     });
   }
 
+  bool hasUncondBranches(const OpcodeCache &OpCC) const {
+    return std::any_of(begin(), end(), [&OpCC](auto &Hist) {
+      auto *Desc = OpCC.desc(Hist.first);
+      return Desc && Desc->isUnconditionalBranch();
+    });
+  }
+
   bool hasCallInstrs(const OpcodeCache &OpCC, const SnippyTarget &Tgt) const;
 
   unsigned getCFInstrsNum(unsigned InstrsNum, const OpcodeCache &OpCC) const {

--- a/llvm/tools/llvm-snippy/lib/Generator/CFPermutation.cpp
+++ b/llvm/tools/llvm-snippy/lib/Generator/CFPermutation.cpp
@@ -294,6 +294,15 @@ void llvm::snippy::CFPermutationContext::initOneBlockInfo(
 
 void llvm::snippy::CFPermutationContext::initBlocksInfo(unsigned Size) {
   auto &BS = BranchSettings.get();
+  auto &GenCtx = GC.get();
+  auto &Cfg = GenCtx.getConfig();
+  auto &ProgCtx = GenCtx.getProgramContext();
+
+  if (BS.anyConsecutiveLoops() &&
+      Cfg.hasUncondBranches(ProgCtx.getOpcodeCache()))
+    snippy::fatal(
+        "Consecutive loops are not supported with unconditional branches.");
+
   BlocksInfo.reserve(Size);
   assert(checkBranchSettings(BS) && "unsupported branch settings");
   if (BS.onlyConsecutiveLoops()) {


### PR DESCRIPTION
[snippy] Histogram diagnostic for unconditional branches when the ‘consecutive-loops’ is enabled

This commit adds a check for unconditional branches in histogram if 'consecutive-loops' is enabled. We need this diagnostic because unconditional branches with consecutive loops leeds to infinite loop.