### PR TITLE
[snippy] Exclude AsmParserOnly and CodeGenOnly instructions from OpcodeCache

### DIFF
--- a/llvm/tools/llvm-snippy/lib/Target/RISCV/CMakeLists.txt
+++ b/llvm/tools/llvm-snippy/lib/Target/RISCV/CMakeLists.txt
@@ -3,6 +3,10 @@ include_directories(
   ${LLVM_BINARY_DIR}/lib/Target/RISCV
 )
 
+set(LLVM_TARGET_DEFINITIONS ${PROJECT_SOURCE_DIR}/lib/Target/RISCV/RISCV.td)
+tablegen(SNIPPY RISCVGenerated.inc -gen-riscv -I ${PROJECT_SOURCE_DIR}/lib/Target/RISCV/)
+add_public_tablegen_target(SnippyRISCVTableGen)
+
 set(LLVM_LINK_COMPONENTS
   RISCV
   Core
@@ -18,10 +22,15 @@ add_llvm_library(LLVMSnippyRISCV
   DEPENDS
   intrinsics_gen
   RISCVCommonTableGen
+  SnippyRISCVTableGen
   )
 
 target_link_libraries(
   LLVMSnippyRISCV
   PRIVATE LLVMSnippyConfig LLVMSnippySupport LLVMSnippyTarget
   PUBLIC SnippyHeaders
+  )
+
+target_include_directories(LLVMSnippyRISCV
+  PRIVATE ${CMAKE_CURRENT_BINARY_DIR}
   )

--- a/llvm/tools/llvm-snippy/lib/Target/RISCV/Target.cpp
+++ b/llvm/tools/llvm-snippy/lib/Target/RISCV/Target.cpp
@@ -77,6 +77,10 @@
 #include "RISCVGenInstrInfo.inc"
 #undef GET_AVAILABLE_OPCODE_CHECKER
 
+#define SNIPPY_RISCV_EXCLUDED_OPCODES_DEF
+#include "RISCVGenerated.inc"
+#undef SNIPPY_RISCV_EXCLUDED_OPCODES_DEF
+
 namespace llvm {
 #define GET_REGISTER_MATCHER
 #include "RISCVGenAsmMatcher.inc"
@@ -1098,7 +1102,8 @@ public:
   }
   bool checkOpcodeSupported(int Opcode,
                             const FeatureBitset &Features) const override {
-    return RISCV_MC::isOpcodeAvailable(Opcode, Features);
+    return RISCV_MC::isOpcodeAvailable(Opcode, Features) &&
+           !snippyRISCVIsOpcodeExcluded(Opcode);
   }
   bool isPseudoAllowed(unsigned Opcode) const override {
     switch (Opcode) {

--- a/llvm/tools/llvm-snippy/utils/TableGen/CMakeLists.txt
+++ b/llvm/tools/llvm-snippy/utils/TableGen/CMakeLists.txt
@@ -1,6 +1,13 @@
 include(TableGen)
 set(LLVM_LINK_COMPONENTS Support)
-add_tablegen(snippy-tblgen SNIPPY TableGen.cpp SnippyOptions.cpp)
+
+add_tablegen(snippy-tblgen SNIPPY
+  RISCVGenerated.cpp
+  SnippyOptions.cpp
+  TableGen.cpp
+  )
+
+target_link_libraries(snippy-tblgen PRIVATE LLVMTableGenCommon)
 
 # TODO: Fix cross-compilation. Because snippy is a part of the LLVM (cmake)
 # project its tablegen depends on build_native_tool. That means that llvm-snippy

--- a/llvm/tools/llvm-snippy/utils/TableGen/Emitters.h
+++ b/llvm/tools/llvm-snippy/utils/TableGen/Emitters.h
@@ -1,0 +1,24 @@
+//===- Emitters.h ---------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_TOOLS_LLVM_SNIPPY_UTILS_TABLEGEN_EMITTERS_H
+#define LLVM_TOOLS_LLVM_SNIPPY_UTILS_TABLEGEN_EMITTERS_H
+
+namespace llvm {
+class RecordKeeper;
+class raw_ostream;
+
+namespace snippy {
+
+bool emitRISCVGenerated(llvm::raw_ostream &OS,
+                        const llvm::RecordKeeper &Records);
+
+} // namespace snippy
+} // namespace llvm
+
+#endif // LLVM_TOOLS_LLVM_SNIPPY_UTILS_TABLEGEN_EMITTERS_H

--- a/llvm/tools/llvm-snippy/utils/TableGen/RISCVGenerated.cpp
+++ b/llvm/tools/llvm-snippy/utils/TableGen/RISCVGenerated.cpp
@@ -1,0 +1,95 @@
+//===- RISCVGenerated.cpp -------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "Common/CodeGenInstruction.h"
+
+#include "llvm/TableGen/Error.h"
+#include "llvm/TableGen/Record.h"
+#include "llvm/TableGen/TableGenBackend.h"
+
+namespace llvm {
+namespace snippy {
+
+namespace {
+
+static constexpr unsigned DefaultIndent = 2;
+static constexpr unsigned DoubleIndent = 2 * DefaultIndent;
+
+class SnippyRISCVEmitter {
+  raw_ostream &OS;
+  const RecordKeeper &Records;
+
+  static constexpr const char *RISCVNamespace = "RISCV";
+
+  void emitExcludedOpcodesFuncDecl() const {
+    OS << "bool snippyRISCVIsOpcodeExcluded(unsigned Opc)";
+  }
+
+public:
+  SnippyRISCVEmitter(raw_ostream &OS, const RecordKeeper &Records)
+      : OS(OS), Records(Records) {}
+
+  void emitExcludedOpcodes() {
+    OS << "\n#ifdef SNIPPY_RISCV_EXCLUDED_OPCODES_DECL\n";
+    OS << "#undef SNIPPY_RISCV_EXCLUDED_OPCODES_DECL\n\n";
+    emitExcludedOpcodesFuncDecl();
+    OS << ";\n\n";
+    OS << "#endif\n";
+
+    OS << "\n#ifdef SNIPPY_RISCV_EXCLUDED_OPCODES_DEF\n";
+    OS << "#undef SNIPPY_RISCV_EXCLUDED_OPCODES_DEF\n\n";
+    auto Opts = Records.getAllDerivedDefinitions("Instruction");
+    emitExcludedOpcodesFuncDecl();
+    OS << " {\n";
+    OS.indent(DefaultIndent) << "switch (Opc) {\n";
+    for (auto *R : Opts) {
+      assert(R);
+      auto Ins = CodeGenInstruction(R);
+
+      // We are only interested in RISCV opcodes.
+      if (Ins.Namespace != RISCVNamespace)
+        continue;
+
+      // Only CodeGenOnly and AsmParserOnly instructions are excluded.
+      // Pseudos are handled manually, so they should not be disallowed here.
+      bool IsExcluded =
+          !Ins.isPseudo && (Ins.isCodeGenOnly || Ins.isAsmParserOnly);
+
+      if (!IsExcluded)
+        continue;
+
+      OS.indent(DefaultIndent)
+          << "case " << Ins.Namespace << "::" << R->getName() << ":\n";
+    }
+    OS.indent(DoubleIndent) << "return true;\n";
+    OS.indent(DefaultIndent) << "default:\n";
+    OS.indent(DoubleIndent) << "return false;\n";
+    OS.indent(DefaultIndent) << "}\n";
+    OS << "}\n\n#endif\n";
+  }
+};
+
+} // namespace
+
+bool emitRISCVGenerated(raw_ostream &OS, const RecordKeeper &Records) {
+  SnippyRISCVEmitter Emitter(OS, Records);
+
+  emitSourceFileHeader("Snippy RISCV Generated", OS, Records);
+
+  OS << "namespace llvm {\n";
+  OS << "namespace snippy {\n";
+
+  Emitter.emitExcludedOpcodes();
+
+  OS << "}\n}\n";
+
+  return false;
+}
+
+} // namespace snippy
+} // namespace llvm

--- a/llvm/tools/llvm-snippy/utils/TableGen/TableGen.cpp
+++ b/llvm/tools/llvm-snippy/utils/TableGen/TableGen.cpp
@@ -6,6 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include "Emitters.h"
 #include "SnippyOptions.h"
 #include "llvm/Support/CommandLine.h"
 #include "llvm/Support/ManagedStatic.h"
@@ -22,6 +23,7 @@ enum ActionType {
   DumpJSON,
   GenOptions,
   GenOptionsStruct,
+  GenRISCV,
 };
 
 static cl::opt<ActionType>
@@ -33,7 +35,9 @@ static cl::opt<ActionType>
                       clEnumValN(GenOptionsStruct, "gen-options-struct",
                                  "Generate option struct definition"),
                       clEnumValN(GenOptions, "gen-options",
-                                 "Generate option definitions")));
+                                 "Generate option definitions"),
+                      clEnumValN(GenRISCV, "gen-riscv",
+                                 "Generate RISCV Target definitions")));
 
 static bool snippyTableGenMain(raw_ostream &OS, const RecordKeeper &Records) {
   switch (Action) {
@@ -48,6 +52,9 @@ static bool snippyTableGenMain(raw_ostream &OS, const RecordKeeper &Records) {
     break;
   case GenOptionsStruct:
     emitSnippyOptionsStruct(OS, Records);
+    break;
+  case GenRISCV:
+    emitRISCVGenerated(OS, Records);
     break;
   }
 


### PR DESCRIPTION
[snippy] Exclude AsmParserOnly and CodeGenOnly instructions from OpcodeCache

This change excludes AsmParserOnly from the list of supported opcodes.
Prior to this `-list-opcode-names` listed assembler-only insn directives
as valid opcodes:

```
12822 Insn32
12823 InsnB
12833 InsnI
12834 InsnI_Mem
12835 InsnJ
12836 InsnR
12837 InsnR4
12838 InsnS
12839 InsnU
```