### PR TITLE
[snippy][fix] set correct alignment for FP register values

### DIFF
--- a/llvm/test/tools/llvm-snippy/fp-regs-init-from-memory-small-r-section.yaml
+++ b/llvm/test/tools/llvm-snippy/fp-regs-init-from-memory-small-r-section.yaml
@@ -1,0 +1,30 @@
+# RUN: llvm-snippy %s -model-plugin=None
+
+options:
+  mtriple: riscv64-unknown-elf
+  riscv-init-fregs-from-memory: true
+  verify-gen-histogram: true
+  histogram-must-succeed: true
+  mattr: +f,+d
+  init-regs-in-elf: true
+  num-instrs: 500
+
+sections:
+  - no: 1
+    VMA: 0x1000
+    LMA: 0x1000
+    SIZE: 0x1000
+    ACCESS: rx
+  - no: 2
+    VMA: 0x2000
+    LMA: 0x2000
+    SIZE: 0x100 # exactly 32 * 8
+    ACCESS: r
+  - no: 3
+    VMA: 0x3000
+    LMA: 0x3000
+    SIZE: 0x1000
+    ACCESS: rw
+
+histogram:
+  - [FADD_D, 1.0]

--- a/llvm/tools/llvm-snippy/lib/Target/RISCV/Target.cpp
+++ b/llvm/tools/llvm-snippy/lib/Target/RISCV/Target.cpp
@@ -3609,7 +3609,7 @@ void SnippyRISCVTarget::generateWriteValueFP(
         IGC.getSnippyModule(),
         "Failed to allocate global constant for float register value load");
     auto *GV = GP.createGV(
-        Value, /* Alignment */ NumBits,
+        Value, /* Alignment */ NumBits / RISCV_CHAR_BIT,
         /* Linkage */ GlobalValue::InternalLinkage,
         /* Name */ "global",
         /* Reason */ "This is needed for updating of float register");


### PR DESCRIPTION
[snippy][fix] set correct alignment for FP register values

Before this commit FP values were aligned to the bit width of the FP
register. Which caused required r section to be 8 times larger than
necessary.