### PR TITLE
[snippy] Allow modifying CSRs inside loops with selfcheck

### DIFF
--- a/llvm/tools/llvm-snippy/Model/RISCVModel/RVM.h
+++ b/llvm/tools/llvm-snippy/Model/RISCVModel/RVM.h
@@ -16,7 +16,7 @@ extern "C" {
 
 #define RVMAPI_ENTRY_POINT_SYMBOL RVMVTable
 #define RVMAPI_VERSION_SYMBOL RVMInterfaceVersion
-#define RVMAPI_CURRENT_INTERFACE_VERSION 28u
+#define RVMAPI_CURRENT_INTERFACE_VERSION 29u
 
 typedef uint64_t RVMRegT;
 
@@ -311,8 +311,8 @@ typedef enum {
   RVM_CSR_VLENB = 0xC22,
 } RVMCSR;
 
-RVMRegT rvm_readCSRReg(const RVMState *State, unsigned Reg);
-void rvm_setCSRReg(RVMState *State, unsigned Reg, RVMRegT Value);
+RVMRegT rvm_readCSR(const RVMState *State, unsigned Reg);
+void rvm_setCSR(RVMState *State, unsigned Reg, RVMRegT Value);
 
 typedef enum {
   RVM_V_REG_0 = 0,
@@ -368,6 +368,8 @@ typedef void (*FRegUpdateCallbackTy)(RVMCallbackHandler *, RVMFReg Reg,
                                      RVMRegT Value);
 typedef void (*VRegUpdateCallbackTy)(RVMCallbackHandler *, RVMVReg Reg,
                                      const char *Data, size_t Size);
+typedef void (*CSRUpdateCallbackTy)(RVMCallbackHandler *, RVMCSR CSR,
+                                    uint64_t Value);
 typedef void (*PCUpdateCallbackTy)(RVMCallbackHandler *, uint64_t PC);
 
 struct RVMMemoryRegion {
@@ -392,6 +394,7 @@ struct RVMConfig {
   XRegUpdateCallbackTy XRegUpdateCallback;
   FRegUpdateCallbackTy FRegUpdateCallback;
   VRegUpdateCallbackTy VRegUpdateCallback;
+  CSRUpdateCallbackTy CSRUpdateCallback;
   PCUpdateCallbackTy PCUpdateCallback;
   int ChangeMaskAgnosticElems;
   int ChangeTailAgnosticElems;
@@ -413,8 +416,8 @@ typedef RVMRegT (*rvm_readFReg_t)(const RVMState *, RVMFReg);
 typedef void (*rvm_setFReg_t)(RVMState *, RVMFReg, RVMRegT);
 typedef void (*rvm_setStopMode_t)(RVMState *, RVMStopMode);
 typedef void (*rvm_setStopPC_t)(RVMState *, uint64_t);
-typedef RVMRegT (*rvm_readCSRReg_t)(const RVMState *, unsigned);
-typedef void (*rvm_setCSRReg_t)(RVMState *, unsigned, RVMRegT);
+typedef RVMRegT (*rvm_readCSR_t)(const RVMState *, unsigned);
+typedef void (*rvm_setCSR_t)(RVMState *, unsigned, RVMRegT);
 typedef int (*rvm_readVReg_t)(const RVMState *, RVMVReg, char *, size_t);
 typedef int (*rvm_setVReg_t)(RVMState *, RVMVReg, const char *, size_t);
 typedef void (*rvm_logMessage_t)(const RVMState *, const char *);

--- a/llvm/tools/llvm-snippy/Model/RISCVModel/RVM.hpp
+++ b/llvm/tools/llvm-snippy/Model/RISCVModel/RVM.hpp
@@ -280,6 +280,11 @@ public:
       return *this;
     }
 
+    Builder &registerCSRUpdateCallback(CSRUpdateCallbackTy Callback) {
+      Config.CSRUpdateCallback = Callback;
+      return *this;
+    }
+
     Builder &registerPCUpdateCallback(PCUpdateCallbackTy Callback) {
       Config.PCUpdateCallback = Callback;
       return *this;
@@ -388,12 +393,12 @@ public:
     return getVTable()->setFReg(get(), Reg, Value);
   }
 
-  RVMRegT readCSRReg(unsigned Reg) const {
-    return getVTable()->readCSRReg(get(), Reg);
+  RVMRegT readCSR(unsigned Reg) const {
+    return getVTable()->readCSR(get(), Reg);
   }
 
-  void setCSRReg(unsigned Reg, RVMRegT Value) {
-    return getVTable()->setCSRReg(get(), Reg, Value);
+  void setCSR(unsigned Reg, RVMRegT Value) {
+    return getVTable()->setCSR(get(), Reg, Value);
   }
 
   int readVReg(RVMVReg Reg, char *Data, size_t MaxSize) const {

--- a/llvm/tools/llvm-snippy/Model/RISCVModel/VTable.h
+++ b/llvm/tools/llvm-snippy/Model/RISCVModel/VTable.h
@@ -38,8 +38,8 @@ struct RVM_FunctionPointers {
   rvm_readFReg_t readFReg;
   rvm_setFReg_t setFReg;
 
-  rvm_readCSRReg_t readCSRReg;
-  rvm_setCSRReg_t setCSRReg;
+  rvm_readCSR_t readCSR;
+  rvm_setCSR_t setCSR;
 
   rvm_readVReg_t readVReg;
   rvm_setVReg_t setVReg;

--- a/llvm/tools/llvm-snippy/include/snippy/Generator/Interpreter.h
+++ b/llvm/tools/llvm-snippy/include/snippy/Generator/Interpreter.h
@@ -278,6 +278,7 @@ public:
   // transaction.
   TransactionStack::AddrToDataType getMemBeforeTransaction() const;
   TransactionStack::RegIdToValueType getXRegsBeforeTransaction() const;
+  TransactionStack::RegIdToValueType getCSRsBeforeTransaction() const;
   TransactionStack::RegIdToValueType getFRegsBeforeTransaction() const;
   TransactionStack::VRegIdToValueType getVRegsBeforeTransaction() const;
   ProgramCounterType getPCBeforeTransaction() const;

--- a/llvm/tools/llvm-snippy/include/snippy/Simulator/Observer.h
+++ b/llvm/tools/llvm-snippy/include/snippy/Simulator/Observer.h
@@ -26,6 +26,7 @@ struct Observer {
   virtual void xregUpdateNotification(unsigned RegID, RegisterType Value) {}
   virtual void fregUpdateNotification(unsigned RegID, RegisterType Value) {}
   virtual void vregUpdateNotification(unsigned RegID, ArrayRef<char> Data) {}
+  virtual void csrUpdateNotification(unsigned RegID, RegisterType Value) {}
   virtual void PCUpdateNotification(ProgramCounterType PC) {}
 
   virtual ~Observer() {}

--- a/llvm/tools/llvm-snippy/include/snippy/Simulator/Simulator.h
+++ b/llvm/tools/llvm-snippy/include/snippy/Simulator/Simulator.h
@@ -78,6 +78,9 @@ public:
 
   virtual void setGPR(unsigned RegID, RegisterType NewValue) = 0;
 
+  virtual RegisterType readCSR(unsigned RegID) const = 0;
+  virtual void setCSR(unsigned RegID, RegisterType NewValue) = 0;
+
   virtual RegisterType readFPR(unsigned RegID) const = 0;
   virtual void setFPR(unsigned RegID, RegisterType NewValue) = 0;
 
@@ -109,6 +112,9 @@ public:
   virtual void dumpSystemRegistersState(raw_ostream &OS) const = 0;
 
   virtual bool supportsCallbacks() const = 0;
+
+  virtual std::vector<std::pair<unsigned, RegisterType>>
+  getCSRValues() const = 0;
 
   virtual ~SimulatorInterface() {}
 };

--- a/llvm/tools/llvm-snippy/include/snippy/Simulator/Transactions.h
+++ b/llvm/tools/llvm-snippy/include/snippy/Simulator/Transactions.h
@@ -31,6 +31,7 @@ public:
     // we shouldn't use any dedicated types. Looks like one more
     // target-dependent layer of abstraction is required.
     RegIdToValueType XRegs;
+    RegIdToValueType CSRs;
     RegIdToValueType FRegs;
     VRegIdToValueType VRegs;
     std::optional<ProgramCounterType> PC;
@@ -43,6 +44,7 @@ public:
   struct Snapshot {
     MemSnapshotType Mem;
     RegSnapshotType XRegs;
+    RegSnapshotType CSRs;
     RegSnapshotType FRegs;
     VRegSnapshotType VRegs;
     ProgramCounterType PC;
@@ -57,12 +59,14 @@ public:
   void memUpdateNotification(MemoryAddressType Addr, const char *Data,
                              size_t Size) override;
   void xregUpdateNotification(unsigned RegID, RegisterType Value) override;
+  void csrUpdateNotification(unsigned RegID, RegisterType Value) override;
   void fregUpdateNotification(unsigned RegID, RegisterType Value) override;
   void vregUpdateNotification(unsigned RegID, ArrayRef<char> Data) override;
   void PCUpdateNotification(ProgramCounterType PC) override;
 
   void addMemSnapshot(MemoryAddressType Addr, std::vector<char> Snapshot);
   void addXRegToSnapshot(unsigned RegID, RegisterType Value);
+  void addCSRToSnapshot(unsigned RegID, RegisterType Value);
   void addFRegToSnapshot(unsigned RegID, RegisterType Value);
   void addVRegToSnapshot(unsigned RegID, VectorRegisterType Value);
   void addPCToSnapshot(ProgramCounterType PC);
@@ -71,12 +75,14 @@ public:
   // transaction.
   AddrToDataType getMemBeforeTransaction() const;
   RegIdToValueType getXRegsBeforeTransaction() const;
+  RegIdToValueType getCSRsBeforeTransaction() const;
   RegIdToValueType getFRegsBeforeTransaction() const;
   VRegIdToValueType getVRegsBeforeTransaction() const;
   ProgramCounterType getPCBeforeTransaction() const;
 
   const AddrToDataType &getMemChangedByTransaction() const;
   const RegIdToValueType &getXRegsChangedByTransaction() const;
+  const RegIdToValueType &getCSRsChangedByTransaction() const;
   const RegIdToValueType &getFRegsChangedByTransaction() const;
   const VRegIdToValueType &getVRegsChangedByTransaction() const;
   ProgramCounterType getPC() const;
@@ -96,6 +102,9 @@ private:
   RegisterType
   getXRegPrevValue(unsigned RegID,
                    TransactionsType::const_reverse_iterator I) const;
+  RegisterType
+  getCSRPrevValue(unsigned RegID,
+                  TransactionsType::const_reverse_iterator I) const;
   RegisterType
   getFRegPrevValue(unsigned RegID,
                    TransactionsType::const_reverse_iterator I) const;

--- a/llvm/tools/llvm-snippy/include/snippy/Target/Target.h
+++ b/llvm/tools/llvm-snippy/include/snippy/Target/Target.h
@@ -483,6 +483,9 @@ public:
   virtual void writeValueToReg(InstructionGenerationContext &IGC, APInt Value,
                                unsigned DstReg) const = 0;
 
+  virtual void writeValueToCSR(InstructionGenerationContext &IGC, APInt Value,
+                               unsigned DstReg) const = 0;
+
   virtual void copyRegToReg(InstructionGenerationContext &IGC, MCRegister Rs,
                             MCRegister Rd) const = 0;
 

--- a/llvm/tools/llvm-snippy/lib/Simulator/Common.h
+++ b/llvm/tools/llvm-snippy/lib/Simulator/Common.h
@@ -36,8 +36,17 @@ public:
   RegisterType readFPR(unsigned RegID) const override {
     return ModelState.readFReg(static_cast<FPRType>(RegID));
   }
+
   void setFPR(unsigned RegID, RegisterType NewValue) override {
     ModelState.setFReg(static_cast<FPRType>(RegID), NewValue);
+  }
+
+  RegisterType readCSR(unsigned RegID) const override {
+    return ModelState.readCSR(RegID);
+  }
+
+  void setCSR(unsigned RegID, RegisterType NewValue) override {
+    ModelState.setCSR(RegID, NewValue);
   }
 
   void readMem(MemoryAddressType Addr,

--- a/llvm/tools/llvm-snippy/lib/Target/RISCV/Target.cpp
+++ b/llvm/tools/llvm-snippy/lib/Target/RISCV/Target.cpp
@@ -3010,6 +3010,24 @@ public:
     addGeneratedInstrsToBB(IGC, InstrsForWrite, *this);
   }
 
+  void writeValueToCSR(InstructionGenerationContext &IGC, APInt Value,
+                       unsigned CSR) const override {
+    auto &MBB = IGC.MBB;
+    auto &Ins = IGC.Ins;
+    auto &ProgCtx = IGC.ProgCtx;
+    auto &State = ProgCtx.getLLVMState();
+    auto &InstrInfo = State.getInstrInfo();
+    auto &Ctx = MBB.getParent()->getFunction().getContext();
+
+    using namespace RISCVSimulatorSysRegs;
+    using namespace RISCVFPRndMode;
+
+    getSupportInstBuilder(*this, MBB, Ins, Ctx, InstrInfo.get(RISCV::CSRRWI),
+                          RISCV::X0)
+        .addImm(lookupSysReg(static_cast<RISCVSimulatorSysReg>(CSR))->Encoding)
+        .addImm(Value.getZExtValue());
+  }
+
   void copyRegToReg(InstructionGenerationContext &IGC, MCRegister Rs,
                     MCRegister Rd) const override {
     assert(RISCV::GPRRegClass.contains(Rs) && RISCV::GPRRegClass.contains(Rd) &&

--- a/llvm/tools/llvm-snippy/lib/Target/X86/Target.cpp
+++ b/llvm/tools/llvm-snippy/lib/Target/X86/Target.cpp
@@ -428,6 +428,10 @@ public:
                        unsigned DstReg) const override {
     reportUnimplementedError();
   }
+  void writeValueToCSR(InstructionGenerationContext &IGC, APInt Value,
+                       unsigned DstReg) const override {
+    reportUnimplementedError();
+  }
 
   void copyRegToReg(InstructionGenerationContext &IGC, MCRegister Rs,
                     MCRegister Rd) const override {


### PR DESCRIPTION
\[snippy\] Allow modifying CSRs inside loops with selfcheck

This commit makes it possible to generate CSR reads and writes inside loops with selfcheck/hazard modes with introduction of CSR update callbacks.