### PR TITLE
[snippy][fix] use correct units for reg width

### DIFF
--- a/llvm/tools/llvm-snippy/include/snippy/Simulator/Targets/RISCV.h
+++ b/llvm/tools/llvm-snippy/include/snippy/Simulator/Targets/RISCV.h
@@ -120,10 +120,10 @@ struct RISCVRegisterState : public IRegisterState {
 
   static uint64_t getMaxRegValueForSize(RegSizeInBytes Size);
 
-  static uint64_t getMaxRegValueForSize(Register Reg, unsigned XLen,
+  static uint64_t getMaxRegValueForSize(Register Reg, unsigned XLenBits,
                                         unsigned VLen);
 
-  static RegSizeInBytes getRegSizeInBytes(Register Reg, unsigned XLen,
+  static RegSizeInBytes getRegSizeInBytes(Register Reg, unsigned XLenBits,
                                           unsigned VLen);
 
 private:

--- a/llvm/tools/llvm-snippy/lib/Target/RISCV/Target.cpp
+++ b/llvm/tools/llvm-snippy/lib/Target/RISCV/Target.cpp
@@ -1947,7 +1947,7 @@ public:
     }
   }
 
-  static unsigned getMaxGenValueForRegs(InstructionGenerationContext &IGC,
+  static uint64_t getMaxGenValueForRegs(InstructionGenerationContext &IGC,
                                         const Branchegram &Branches,
                                         ArrayRef<Register> ReservedRegs) {
     auto &ProgCtx = IGC.ProgCtx;
@@ -1955,13 +1955,13 @@ public:
     auto VLEN =
         ProgCtx.getTargetContext().getImpl<RISCVGeneratorContext>().getVLEN();
     auto CounterReg = ReservedRegs[CounterRegIdx];
-    unsigned MaxCounterRegVal = RISCVRegisterState::getMaxRegValueForSize(
+    auto MaxCounterRegVal = RISCVRegisterState::getMaxRegValueForSize(
         CounterReg, ST.getXLen(), VLEN);
     if (ReservedRegs.size() == 1)
       return MaxCounterRegVal;
 
     auto LimitReg = ReservedRegs[LimitRegIdx];
-    unsigned MaxLimitRegVal =
+    auto MaxLimitRegVal =
         RISCVRegisterState::getMaxRegValueForSize(LimitReg, ST.getXLen(), VLEN);
     return std::min(MaxCounterRegVal, MaxLimitRegVal);
   }


### PR DESCRIPTION
[snippy][fix] use correct units for reg width

Before this commit RISCVRegisterState::getMaxRegValueForSize was
expecting XLen value in bytes but was getting it in bits, which caused
assigning 64 to RegSizeInBytes enum variable (which is out of range for
this non-class enum type).