### PR TITLE
[snippy] Section names prefix override option

### DIFF
--- a/llvm/test/tools/llvm-snippy/linker-sections-prefix.yaml
+++ b/llvm/test/tools/llvm-snippy/linker-sections-prefix.yaml
@@ -1,0 +1,53 @@
+# RUN: llvm-snippy %s -mtriple=riscv64-unknown-gnu -model-plugin=None \
+# RUN:    -num-instrs=10 -o %t
+# RUN: llvm-readelf -S %t.elf |& FileCheck %s --check-prefix=DEFAULT_ELF
+# RUN: FileCheck %s --input-file=%t.ld --check-prefix=DEFAULT_LS
+# RUN: llvm-snippy %s -mtriple=riscv64-unknown-gnu -model-plugin=None \
+# RUN:    -num-instrs=10 -sections-prefix=snippy_sections -o %t
+# RUN: llvm-readelf -S %t.elf |& FileCheck %s --check-prefix=ELF
+# RUN: FileCheck %s --input-file=%t.ld --check-prefix=LINKER_SCRIPT
+
+sections:
+    - name:      text
+      VMA:       0x100000
+      SIZE:      0x200000
+      LMA:       0x100000
+      ACCESS:    rx
+    - name:      data
+      VMA:       0x4000000
+      SIZE:      0x20000
+      LMA:       0x4000000
+      ACCESS:    rw
+    - name:      stack
+      VMA:       0x5000000
+      SIZE:      0x20000
+      LMA:       0x5000000
+      ACCESS:    rw
+    - name:      selfcheck
+      VMA:       0x7000000
+      SIZE:      0x20000
+      LMA:       0x7000000
+      ACCESS:    rw
+
+histogram:
+    - [ADDI, 1.0]
+
+# DEFAULT_LS: .snippy.text.rx
+# DEFAULT_LS: .snippy.data.rw
+# DEFAULT_LS: .snippy.stack.rw
+# DEFAULT_LS: .snippy.selfcheck.rw
+
+# DEFAULT_ELF: .snippy.text.rx
+# DEFAULT_ELF: .snippy.data.rw
+# DEFAULT_ELF: .snippy.stack.rw
+# DEFAULT_ELF: .snippy.selfcheck.rw
+
+# LINKER_SCRIPT: snippy_sections.text.rx
+# LINKER_SCRIPT: snippy_sections.data.rw
+# LINKER_SCRIPT: snippy_sections.stack.rw
+# LINKER_SCRIPT: snippy_sections.selfcheck.rw
+
+# ELF: snippy_sections.text.rx
+# ELF: snippy_sections.data.rw
+# ELF: snippy_sections.stack.rw
+# ELF: snippy_sections.selfcheck.rw

--- a/llvm/tools/llvm-snippy/docs/index.rst
+++ b/llvm/tools/llvm-snippy/docs/index.rst
@@ -2422,7 +2422,7 @@ This setting has the same value in all functions in the call graph.
 .. _`_section_names_prefix`:
 
 Section names prefix
---------------
+--------------------
 
 You can override section names prefix in the output file using ``--sections-prefix=<string>``.
 

--- a/llvm/tools/llvm-snippy/docs/index.rst
+++ b/llvm/tools/llvm-snippy/docs/index.rst
@@ -2419,6 +2419,23 @@ The options are:
 
 This setting has the same value in all functions in the call graph.
 
+.. _`_section_names_prefix`:
+
+Section names prefix
+--------------
+
+You can override section names prefix in the output file using ``--sections-prefix=<string>``.
+
+By default, snippy uses ``.snippy`` as a section names prefix. For example:
+
+::
+
+   .snippy.text.rx
+   .snippy.data.rw
+   .snippy.stack.rw
+
+etc.
+
 .. _`_target_specific_configurationrisc_v`:
 
 Target-Specific Configuration -- RISC-V

--- a/llvm/tools/llvm-snippy/lib/Generator/Linker.cpp
+++ b/llvm/tools/llvm-snippy/lib/Generator/Linker.cpp
@@ -42,6 +42,11 @@ static snippy::opt<bool>
                           "linker script for better readability"),
                  cl::cat(Options), cl::init(false));
 
+static snippy::opt<std::string>
+    SectionNamesPrefix("sections-prefix",
+                       cl::desc("Override section names prefix."),
+                       cl::cat(Options), cl::init(".snippy"));
+
 namespace {
 
 using FilePathT = SmallString<20>;
@@ -240,8 +245,8 @@ void Linker::LinkedSections::addInputSectionFor(const SectionDesc &Desc,
 }
 
 std::string Linker::getMangledName(StringRef SectionName) const {
-  return (".snippy" + Twine(MangleName.empty() ? "" : ".") + MangleName +
-          SectionName)
+  return (SectionNamesPrefix.getValue() + Twine(MangleName.empty() ? "" : ".") +
+          MangleName + SectionName)
       .str();
 }
 


### PR DESCRIPTION
[snippy] Section names prefix override option

This commit adds a new snippy option "sections-prefix" that changes section names prefix ("snippy" by default).