### PR TITLE
[snippy] C_JR generation as a branch

### DIFF
--- a/llvm/lib/Target/RISCV/RISCVInstrInfoC.td
+++ b/llvm/lib/Target/RISCV/RISCVInstrInfoC.td
@@ -546,6 +546,17 @@ def C_JR : RVInst16CR<0b1000, 0b10, (outs), (ins GPRNoX0:$rs1),
   let rs2 = 0;
 }
 
+let isBarrier = 1, isTerminator = 1, isBranch = 1,
+    isIndirectBranch = 1, hasSideEffects = 0, mayLoad = 0,
+    mayStore = 0 in
+def PseudoC_JRB : Pseudo<(outs), (ins GPRNoX0X1:$rs1), []>,
+            PseudoInstExpansion<(C_JR GPRNoX0:$rs1)>;
+
+let hasSideEffects = 0, mayLoad = 0, mayStore = 0, isCodeGenOnly = 1,
+    isAsmParserOnly = 0, Size = 10, isTerminator = 1, isBranch = 1,
+    isIndirectBranch = 1, isBarrier = 1 in
+def PseudoSnippyC_JRB : Pseudo<(outs), (ins bare_symbol:$src), []>;
+
 let hasSideEffects = 0, mayLoad = 0, mayStore = 0, isMoveReg = 1,
     isAsCheapAsAMove = 1 in
 def C_MV : RVInst16CR<0b1000, 0b10, (outs GPRNoX0:$rs1), (ins GPRNoX0:$rs2),

--- a/llvm/lib/Target/RISCV/RISCVRegisterInfo.td
+++ b/llvm/lib/Target/RISCV/RISCVRegisterInfo.td
@@ -252,6 +252,8 @@ def GPRX5 : GPRRegisterClass<(add X5)>;
 
 def GPRNoX0 : GPRRegisterClass<(sub GPR, X0)>;
 
+def GPRNoX0X1 : GPRRegisterClass<(sub GPRNoX0, X1)>;
+
 def GPRNoX0X2 : GPRRegisterClass<(sub GPR, X0, X2)>;
 
 def GPRX7 : GPRRegisterClass<(add X7)>;

--- a/llvm/test/tools/llvm-snippy/branches/c-jr-uniform.yaml
+++ b/llvm/test/tools/llvm-snippy/branches/c-jr-uniform.yaml
@@ -1,0 +1,26 @@
+# RUN: not llvm-snippy -model-plugin=None          \
+# RUN:      -mtriple=riscv64-unknown-elf -mattr=+c \
+# RUN:      -num-instrs=500 %s                     \
+# RUN: |& FileCheck %s
+
+sections:
+    - name:      text
+      VMA:       0x100000
+      SIZE:      0x200000
+      LMA:       0x100000
+      ACCESS:    rx
+    - name:      data
+      VMA:       0x4000000
+      SIZE:      0x20000
+      LMA:       0x4000000
+      ACCESS:    rw
+    - name:      stack
+      VMA:       0x5000000
+      SIZE:      0x20000
+      LMA:       0x5000000
+      ACCESS:    rw
+
+histogram:
+    - [C_JR, 1.0]
+
+#CHECK: error:

--- a/llvm/test/tools/llvm-snippy/branches/pseudo-c-jr-branch.yaml
+++ b/llvm/test/tools/llvm-snippy/branches/pseudo-c-jr-branch.yaml
@@ -1,0 +1,22 @@
+# RUN: llvm-snippy -mtriple=riscv64-unknown-elf -mattr=+c \
+# RUN:      -num-instrs=500 -model-plugin=None %s
+
+sections:
+    - name:      text
+      VMA:       0x100000
+      SIZE:      0x200000
+      LMA:       0x100000
+      ACCESS:    rx
+    - name:      data
+      VMA:       0x4000000
+      SIZE:      0x20000
+      LMA:       0x4000000
+      ACCESS:    rw
+    - name:      stack
+      VMA:       0x5000000
+      SIZE:      0x20000
+      LMA:       0x5000000
+      ACCESS:    rw
+
+histogram:
+    - [PseudoC_JRB, 1.0]

--- a/llvm/test/tools/llvm-snippy/branches/pseudo-c-jr-with-another-branches.yaml
+++ b/llvm/test/tools/llvm-snippy/branches/pseudo-c-jr-with-another-branches.yaml
@@ -1,0 +1,27 @@
+# RUN: llvm-snippy -model-plugin=None                                \
+# RUN:      -mtriple=riscv64-unknown-elf -mattr=+c                   \
+# RUN:      -num-instrs=500 %s
+
+sections:
+    - name:      text
+      VMA:       0x100000
+      SIZE:      0x200000
+      LMA:       0x100000
+      ACCESS:    rx
+    - name:      data
+      VMA:       0x4000000
+      SIZE:      0x20000
+      LMA:       0x4000000
+      ACCESS:    rw
+    - name:      stack
+      VMA:       0x5000000
+      SIZE:      0x20000
+      LMA:       0x5000000
+      ACCESS:    rw
+
+histogram:
+    - [PseudoC_JRB, 1.0]
+    - [BNE, 1.0]
+    - [BEQ, 1.0]
+    - [C_J, 1.0]
+    - [BLT, 1.0]

--- a/llvm/test/tools/llvm-snippy/branches/pseudo-c-jr-with-branchegram.yaml
+++ b/llvm/test/tools/llvm-snippy/branches/pseudo-c-jr-with-branchegram.yaml
@@ -1,0 +1,30 @@
+# RUN: llvm-snippy -model-plugin=None                                \
+# RUN:      -mtriple=riscv64-unknown-elf -mattr=+c                   \
+# RUN:      -num-instrs=500 %s
+
+sections:
+    - name:      text
+      VMA:       0x100000
+      SIZE:      0x200000
+      LMA:       0x100000
+      ACCESS:    rx
+    - name:      data
+      VMA:       0x4000000
+      SIZE:      0x20000
+      LMA:       0x4000000
+      ACCESS:    rw
+    - name:      stack
+      VMA:       0x5000000
+      SIZE:      0x20000
+      LMA:       0x5000000
+      ACCESS:    rw
+
+histogram:
+    - [PseudoC_JRB, 1.0]
+
+branches:
+  number-of-loop-iterations:
+    min: 1
+    max: 2
+  max-depth:
+    loop: 3

--- a/llvm/test/tools/llvm-snippy/branches/pseudo-c-jr-with-consequtive-loops.yaml
+++ b/llvm/test/tools/llvm-snippy/branches/pseudo-c-jr-with-consequtive-loops.yaml
@@ -1,0 +1,31 @@
+# RUN: not llvm-snippy -model-plugin=None                           \
+# RUN:      -mtriple=riscv64-unknown-elf -mattr=+c                  \
+# RUN:      -num-instrs=500 %s                                      \
+# RUN: |& FileCheck %s
+sections:
+    - name:      text
+      VMA:       0x100000
+      SIZE:      0x200000
+      LMA:       0x100000
+      ACCESS:    rx
+    - name:      data
+      VMA:       0x4000000
+      SIZE:      0x20000
+      LMA:       0x4000000
+      ACCESS:    rw
+    - name:      stack
+      VMA:       0x5000000
+      SIZE:      0x20000
+      LMA:       0x5000000
+      ACCESS:    rw
+
+histogram:
+    - [PseudoC_JRB, 1.0]
+
+branches:
+  consecutive-loops: 3
+  loop-ratio: 1.0
+  max-depth:
+    loop: 1
+
+# CHECK: error: Consecutive loops are not supported with indirect branches

--- a/llvm/test/tools/llvm-snippy/branches/pseudo-c-jr-with-loop-ratio-one.yaml
+++ b/llvm/test/tools/llvm-snippy/branches/pseudo-c-jr-with-loop-ratio-one.yaml
@@ -1,0 +1,26 @@
+# RUN: llvm-snippy -model-plugin=None                                \
+# RUN:      -mtriple=riscv64-unknown-elf -mattr=+c                   \
+# RUN:      -num-instrs=500 %s
+
+sections:
+    - name:      text
+      VMA:       0x100000
+      SIZE:      0x200000
+      LMA:       0x100000
+      ACCESS:    rx
+    - name:      data
+      VMA:       0x4000000
+      SIZE:      0x20000
+      LMA:       0x4000000
+      ACCESS:    rw
+    - name:      stack
+      VMA:       0x5000000
+      SIZE:      0x20000
+      LMA:       0x5000000
+      ACCESS:    rw
+
+histogram:
+    - [PseudoC_JRB, 1.0]
+
+branches:
+  loop-ratio: 1.0

--- a/llvm/test/tools/llvm-snippy/branches/pseudo-c-jr-with-max-depth-zero.yaml
+++ b/llvm/test/tools/llvm-snippy/branches/pseudo-c-jr-with-max-depth-zero.yaml
@@ -1,0 +1,28 @@
+# RUN: llvm-snippy -model-plugin=None                                \
+# RUN:      -mtriple=riscv64-unknown-elf -mattr=+c                   \
+# RUN:      -num-instrs=500 %s
+
+sections:
+    - name:      text
+      VMA:       0x100000
+      SIZE:      0x200000
+      LMA:       0x100000
+      ACCESS:    rx
+    - name:      data
+      VMA:       0x4000000
+      SIZE:      0x20000
+      LMA:       0x4000000
+      ACCESS:    rw
+    - name:      stack
+      VMA:       0x5000000
+      SIZE:      0x20000
+      LMA:       0x5000000
+      ACCESS:    rw
+
+histogram:
+    - [PseudoC_JRB, 1.0]
+
+branches:
+  max-depth:
+    loop: 0
+    if: 0

--- a/llvm/tools/llvm-snippy/include/snippy/Config/Config.h
+++ b/llvm/tools/llvm-snippy/include/snippy/Config/Config.h
@@ -357,6 +357,10 @@ public:
     return Histogram.hasUncondBranches(OpCC);
   }
 
+  bool hasIndirectBranches(const OpcodeCache &OpCC) const {
+    return Histogram.hasIndirectBranches(OpCC);
+  }
+
   auto &getTrackCfg() const { return CommonPolicyCfg->TrackCfg; }
 
   bool hasTrackingMode() const {

--- a/llvm/tools/llvm-snippy/include/snippy/Config/OpcodeHistogram.h
+++ b/llvm/tools/llvm-snippy/include/snippy/Config/OpcodeHistogram.h
@@ -87,6 +87,13 @@ public:
     });
   }
 
+  bool hasIndirectBranches(const OpcodeCache &OpCC) const {
+    return std::any_of(begin(), end(), [&OpCC](auto &Hist) {
+      auto *Desc = OpCC.desc(Hist.first);
+      return Desc && Desc->isIndirectBranch();
+    });
+  }
+
   bool hasCallInstrs(const OpcodeCache &OpCC, const SnippyTarget &Tgt) const;
   bool hasSPRelativeInstrs(const OpcodeCache &OpCC,
                            const SnippyTarget &Tgt) const;

--- a/llvm/tools/llvm-snippy/include/snippy/CreatePasses.h
+++ b/llvm/tools/llvm-snippy/include/snippy/CreatePasses.h
@@ -91,5 +91,6 @@ MachineFunctionPass *createMemAccessDumperPass();
 
 MachineFunctionPass *createConsecutiveLoopsVerifierPass();
 
+MachineFunctionPass *createRISCVExpandSnippyPseudoPass();
 
 } // namespace llvm

--- a/llvm/tools/llvm-snippy/include/snippy/Target/Target.h
+++ b/llvm/tools/llvm-snippy/include/snippy/Target/Target.h
@@ -423,6 +423,11 @@ public:
   generateBranch(InstructionGenerationContext &IGC,
                  const MCInstrDesc &InstrDesc) const = 0;
 
+  // Insert indirect jump to TBB by opcode.
+  virtual MachineInstr &insertIndirectJump(InstructionGenerationContext &IGC,
+                                           MachineBasicBlock &TBB,
+                                           unsigned Opcode) const = 0;
+
   virtual bool relaxBranch(MachineInstr &Branch, unsigned Distance,
                            SnippyProgramContext &ProgCtx) const = 0;
 

--- a/llvm/tools/llvm-snippy/lib/Generator/CFPermutation.cpp
+++ b/llvm/tools/llvm-snippy/lib/Generator/CFPermutation.cpp
@@ -245,8 +245,9 @@ void llvm::snippy::CFPermutationContext::initOneBlockInfo(
   assert(BBPtr);
   auto Branch = BBPtr->getFirstTerminator();
   assert(Branch != BBPtr->end());
-  // We don't want want to permute unconditional branches
-  if (Branch->isUnconditionalBranch()) {
+  // We don't want want to permute unconditional branches and temporarily
+  // indirect branches.
+  if (Branch->isUnconditionalBranch() || Branch->isIndirectBranch()) {
     BlocksInfo.emplace_back(BB + 1, BlockInfo::SetT());
     return;
   }
@@ -302,6 +303,10 @@ void llvm::snippy::CFPermutationContext::initBlocksInfo(unsigned Size) {
       Cfg.hasUncondBranches(ProgCtx.getOpcodeCache()))
     snippy::fatal(
         "Consecutive loops are not supported with unconditional branches.");
+  if (BS.anyConsecutiveLoops() &&
+      Cfg.hasIndirectBranches(ProgCtx.getOpcodeCache()))
+    snippy::fatal(
+        "Consecutive loops are not supported with indirect branches.");
 
   BlocksInfo.reserve(Size);
   assert(checkBranchSettings(BS) && "unsupported branch settings");

--- a/llvm/tools/llvm-snippy/lib/Generator/Generation.cpp
+++ b/llvm/tools/llvm-snippy/lib/Generator/Generation.cpp
@@ -1315,9 +1315,12 @@ MachineBasicBlock *findNextBlockOnModel(MachineBasicBlock &MBB,
     if (Branch.isUnconditionalBranch())
       return SnippyTgt.getBranchDestination(Branch);
 
-    assert(!Branch.isIndirectBranch() &&
-           "Indirect branches are not supported for execution on the model "
-           "during code generation.");
+    if (Branch.isIndirectBranch()) {
+      // We only support indirect branches that jump to the next basic block.
+      assert(MBB.getNextNode() == SnippyTgt.getBranchDestination(Branch));
+      return SnippyTgt.getBranchDestination(Branch);
+    }
+
     assert(Branch.isConditionalBranch());
     I.addInstr(Branch, State);
 

--- a/llvm/tools/llvm-snippy/lib/InitializePasses.h
+++ b/llvm/tools/llvm-snippy/lib/InitializePasses.h
@@ -37,6 +37,7 @@ void initializeBranchRelaxatorPass(PassRegistry &);
 void initializeBlockGenPlanningPass(PassRegistry &);
 void initializeBlockGenPlanWrapperPass(PassRegistry &);
 void initializeMemoryAccessDumperPass(llvm::PassRegistry &);
+void initializeRISCVExpandSnippyPseudoPass(PassRegistry &);
 void initializeConsecutiveLoopsVerifierPass(PassRegistry &);
 
 } // namespace llvm

--- a/llvm/tools/llvm-snippy/lib/Target/RISCV/CMakeLists.txt
+++ b/llvm/tools/llvm-snippy/lib/Target/RISCV/CMakeLists.txt
@@ -19,6 +19,7 @@ add_llvm_library(LLVMSnippyRISCV
   RVVUnitConfig.cpp
   Target.cpp
   TargetGenContext.cpp
+  RISCVExpandSnippyPseudoInsts.cpp
   DEPENDS
   intrinsics_gen
   RISCVCommonTableGen

--- a/llvm/tools/llvm-snippy/lib/Target/RISCV/RISCVExpandSnippyPseudoInsts.cpp
+++ b/llvm/tools/llvm-snippy/lib/Target/RISCV/RISCVExpandSnippyPseudoInsts.cpp
@@ -1,0 +1,172 @@
+//===-- RISCVExpandSnippyPseudoInsts.cpp -----------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===---------------------------------------------------------------------===//
+//
+// This file contains a pass that expands snippy specific pseudo instructions
+// into target instructions. This pass should be run before other RISC-V
+// pseudo expand passes.
+//
+//===---------------------------------------------------------------------===//
+
+#include "../../InitializePasses.h"
+#include "snippy/CreatePasses.h"
+#include "snippy/Generator/GenerationUtils.h"
+#include "snippy/Generator/GeneratorContextPass.h"
+#include "snippy/Generator/LLVMState.h"
+#include "snippy/Generator/Policy.h"
+
+#include "MCTargetDesc/RISCVBaseInfo.h"
+#include "RISCVInstrInfo.h"
+#include "RISCVTargetMachine.h"
+#include "llvm/CodeGen/LivePhysRegs.h"
+#include "llvm/CodeGen/MachineFunctionPass.h"
+#include "llvm/CodeGen/MachineInstrBuilder.h"
+#include "llvm/MC/MCContext.h"
+#include "llvm/Target/TargetMachine.h"
+
+using namespace llvm;
+
+#define RISCV_EXPAND_SNIPPY_PSEUDO_NAME                                        \
+  "RISC-V snippy pseudo instruction expansion pass"
+
+namespace {
+
+class RISCVExpandSnippyPseudo : public MachineFunctionPass {
+  const RISCVSubtarget *STI;
+  const RISCVInstrInfo *TII;
+
+public:
+  static char ID;
+
+  RISCVExpandSnippyPseudo() : MachineFunctionPass(ID) {}
+
+  bool runOnMachineFunction(MachineFunction &MF) override;
+
+  StringRef getPassName() const override {
+    return RISCV_EXPAND_SNIPPY_PSEUDO_NAME;
+  }
+
+  void getAnalysisUsage(AnalysisUsage &AU) const override {
+    AU.addRequired<snippy::GeneratorContextWrapper>();
+    MachineFunctionPass::getAnalysisUsage(AU);
+  }
+
+private:
+  bool expandMBB(MachineBasicBlock &MBB);
+  bool expandMI(MachineBasicBlock &MBB, MachineBasicBlock::iterator MBBI);
+  bool expandAuipcInstPair(MachineBasicBlock &MBB,
+                           MachineBasicBlock::iterator MBBI, unsigned FlagsHi,
+                           unsigned SecondOpcode, unsigned DestReg);
+  bool expandC_JRB(MachineBasicBlock &MBB, MachineBasicBlock::iterator MBBI);
+};
+
+char RISCVExpandSnippyPseudo::ID = 0;
+
+bool RISCVExpandSnippyPseudo::runOnMachineFunction(MachineFunction &MF) {
+  STI = &MF.getSubtarget<RISCVSubtarget>();
+  TII = STI->getInstrInfo();
+  auto &SGCtx = getAnalysis<snippy::GeneratorContextWrapper>().getContext();
+  auto &ProgCtx = SGCtx.getProgramContext();
+  auto &State = ProgCtx.getLLVMState();
+
+  [[maybe_unused]] const size_t OldSize = State.getFunctionSize(MF);
+
+  bool Modified = false;
+  for (auto &MBB : MF)
+    Modified |= expandMBB(MBB);
+
+  [[maybe_unused]] const size_t NewSize = State.getFunctionSize(MF);
+  assert(OldSize >= NewSize);
+
+  return Modified;
+}
+
+bool RISCVExpandSnippyPseudo::expandMBB(MachineBasicBlock &MBB) {
+  bool Modified = false;
+
+  for (auto &&MI : make_early_inc_range(MBB))
+    Modified |= expandMI(MBB, MI);
+
+  return Modified;
+}
+
+bool RISCVExpandSnippyPseudo::expandMI(MachineBasicBlock &MBB,
+                                       MachineBasicBlock::iterator MBBI) {
+  switch (MBBI->getOpcode()) {
+  case RISCV::PseudoSnippyC_JRB:
+    return expandC_JRB(MBB, MBBI);
+  }
+  return false;
+}
+
+bool RISCVExpandSnippyPseudo::expandAuipcInstPair(
+    MachineBasicBlock &MBB, MachineBasicBlock::iterator MBBI, unsigned FlagsHi,
+    unsigned SecondOpcode, unsigned DestReg) {
+  MachineFunction *MF = MBB.getParent();
+  MachineInstr &MI = *MBBI;
+  DebugLoc DL = MI.getDebugLoc();
+  auto &SGCtx = getAnalysis<snippy::GeneratorContextWrapper>().getContext();
+  auto &ProgCtx = SGCtx.getProgramContext();
+  auto &State = ProgCtx.getLLVMState();
+  auto &Tgt = State.getSnippyTarget();
+
+  MachineOperand &Symbol = MI.getOperand(0);
+  Symbol.setTargetFlags(FlagsHi);
+  MCSymbol *AUIPCSymbol = MF->getContext().createNamedTempSymbol("pcrel_hi");
+
+  MachineInstr *MIAUIPC = getSupportInstBuilder(Tgt, MBB, MBBI, State.getCtx(),
+                                                TII->get(RISCV::AUIPC), DestReg)
+                              .add(Symbol)
+                              .getInstr();
+  MIAUIPC->setPreInstrSymbol(*MF, AUIPCSymbol);
+
+  getSupportInstBuilder(Tgt, MBB, MBBI, State.getCtx(), TII->get(SecondOpcode),
+                        DestReg)
+      .addReg(DestReg)
+      .addSym(AUIPCSymbol, RISCVII::MO_PCREL_LO)
+      .getInstr();
+
+  return true;
+}
+
+bool RISCVExpandSnippyPseudo::expandC_JRB(MachineBasicBlock &MBB,
+                                          MachineBasicBlock::iterator MBBI) {
+  MachineInstr &MI = *MBBI;
+  DebugLoc DL = MI.getDebugLoc();
+  auto &SGCtx = getAnalysis<snippy::GeneratorContextWrapper>().getContext();
+  auto &ProgCtx = SGCtx.getProgramContext();
+  auto &State = ProgCtx.getLLVMState();
+  auto &Tgt = State.getSnippyTarget();
+
+  auto &RI = State.getRegInfo();
+  snippy::planning::InstructionGenerationContext IGC{
+      MBB, MBB.getFirstTerminator(), SGCtx};
+  auto RP = IGC.pushRegPool();
+  auto &InstrDesc = TII->get(RISCV::PseudoC_JRB);
+  auto &RegClass = RI.getRegClass(InstrDesc.operands()[0].RegClass);
+  unsigned DestReg =
+      RP->getAvailableRegister("c.jr destination register", RI, RegClass, MBB);
+
+  expandAuipcInstPair(MBB, MBBI, RISCVII::MO_PCREL_HI, RISCV::ADDI, DestReg);
+  getMainInstBuilder(Tgt, MBB, MBBI, State.getCtx(), TII->get(RISCV::C_JR),
+                     DestReg);
+  MI.eraseFromParent();
+  return true;
+}
+
+} // namespace
+
+INITIALIZE_PASS(RISCVExpandSnippyPseudo, "riscv-expand-snippy-pseudo",
+                RISCV_EXPAND_SNIPPY_PSEUDO_NAME, false, false)
+
+namespace llvm {
+
+MachineFunctionPass *createRISCVExpandSnippyPseudoPass() {
+  return new RISCVExpandSnippyPseudo();
+}
+
+} // namespace llvm

--- a/llvm/tools/llvm-snippy/lib/Target/X86/Target.cpp
+++ b/llvm/tools/llvm-snippy/lib/Target/X86/Target.cpp
@@ -307,6 +307,12 @@ public:
     reportUnimplementedError();
   }
 
+  MachineInstr &insertIndirectJump(InstructionGenerationContext &IGC,
+                                   MachineBasicBlock &TBB,
+                                   unsigned Opcode) const override {
+    reportUnimplementedError();
+  }
+
   bool relaxBranch(MachineInstr &Branch, unsigned Distance,
                    SnippyProgramContext &ProgCtx) const override {
     reportUnimplementedError();


### PR DESCRIPTION
[snippy] C_JR generation as a branch

This commit adds a new allowed pseudo instruction C_JRB that allows us to generate c.jr as a branch.