### PR TITLE
[snippy] Add 'skip-legacy-sp-spill' to skip spilling SP without honor-target-abi

### DIFF
--- a/llvm/tools/llvm-snippy/include/snippy/Config/Config.h
+++ b/llvm/tools/llvm-snippy/include/snippy/Config/Config.h
@@ -52,6 +52,7 @@ public:
   SmallVector<MCRegister> SpilledToStack;
   SmallVector<MCRegister> SpilledToMem;
   bool ExternalStack;
+  bool SkipLegacySPSpill;
 
   // linker options.
   bool MangleExportedNames;

--- a/llvm/tools/llvm-snippy/lib/Config/Config.cpp
+++ b/llvm/tools/llvm-snippy/lib/Config/Config.cpp
@@ -574,6 +574,7 @@ static void normalizeProgramLevelOptions(Config &Cfg, LLVMState &State,
   ProgCfg.MangleExportedNames = Opts.MangleExportedNames;
   ProgCfg.EntryPointName = Opts.EntryPointName;
   ProgCfg.ExternalStack = Opts.ExternalStack;
+  ProgCfg.SkipLegacySPSpill = Opts.SkipLegacySPSpill;
   ProgCfg.InitialRegYamlFile = Opts.InitialRegisterDataFile;
   ProgCfg.Seed = seedOptToValue(Opts.Seed);
   // FIXME: RandomEngine initialization should be moved out of Config as well
@@ -595,6 +596,11 @@ static void normalizeProgramLevelOptions(Config &Cfg, LLVMState &State,
       snippy::fatal("Incompatible options",
                     "When --honor-target-abi is enabled, generation of "
                     "SP-relative instructions is not supported.");
+
+    if (Opts.SkipLegacySPSpill)
+      snippy::fatal("Incompatible options",
+                    "--skip-legacy-sp-spill option is incompatible with "
+                    "--honor-target-abi");
 
     if (!RegsSpilledToStack.empty())
       snippy::warn(WarningName::InconsistentOptions, Ctx,

--- a/llvm/tools/llvm-snippy/lib/Config/Options.td
+++ b/llvm/tools/llvm-snippy/lib/Config/Options.td
@@ -77,6 +77,10 @@ let Group = ProgramOptionsCategory in {
       : CommaSeparatedList<"reserved-regs-list", StringType>,
         Description<"List of registers that shall not be used om snippet code">;
 
+  def SkipLegacySPSpill
+      : Flag<"skip-legacy-sp-spill">,
+        Description<"Skips legacy stack pointer spill when 'honor-target-abi' is disabled">,
+        Hidden;
 }
 
 def ModelOptionsCategory : OptionGroup<"Snippy Model Options", true> {


### PR DESCRIPTION
[snippy] Add 'skip-legacy-sp-spill' to skip spilling SP without honor-target-abi

Adds a new option that should become the default in new releases. Fix some typos
while we are at it.