### PR TITLE
[snippy] Use external stack by default with honor-target-abi

### DIFF
--- a/llvm/test/tools/llvm-snippy/stack/honor-target-abi-no-stack-uses-external.yaml
+++ b/llvm/test/tools/llvm-snippy/stack/honor-target-abi-no-stack-uses-external.yaml
@@ -1,0 +1,28 @@
+# RUN: llvm-snippy %s -model-plugin=None |& FileCheck %s
+
+options:
+  march: rv64gc
+  mtriple: riscv64-linux-gnu
+  honor-target-abi: true
+
+sections:
+  - name: text
+    VMA: 0x1000
+    LMA: 0x1000
+    SIZE: 0x1000
+    ACCESS: rx
+  - name: data
+    VMA: 0x2000
+    LMA: 0x2000
+    SIZE: 0x1000
+    ACCESS: rw
+
+histogram:
+  - [ADD, 1.0]
+
+# CHECK-NOT: error: Cannot spill requested registers:
+# CHECK-NOT: no stack space allocated.
+# CHECK: warning: (no-model-exec) Skipping snippet execution on the
+# CHECK: model: model was set to 'None'.
+# CHECK: remark: (relocatable-generated) Snippet generator generated
+# CHECK: relocatable image

--- a/llvm/tools/llvm-snippy/lib/Config/Config.cpp
+++ b/llvm/tools/llvm-snippy/lib/Config/Config.cpp
@@ -761,7 +761,9 @@ static void normalizeProgramLevelOptions(Config &Cfg, LLVMState &State,
   ProgCfg.PreserveCallerSavedGroups = Opts.PreserveCallerSavedRegs;
   ProgCfg.MangleExportedNames = Opts.MangleExportedNames;
   ProgCfg.EntryPointName = Opts.EntryPointName;
-  ProgCfg.ExternalStack = Opts.ExternalStack;
+  ProgCfg.ExternalStack =
+      Opts.ExternalStack ||
+      (ProgCfg.FollowTargetABI && !ProgCfg.hasInternalStackSection());
   ProgCfg.SkipLegacySPSpill = Opts.SkipLegacySPSpill;
   ProgCfg.StaticStack = getStaticStackValue(Cfg, OpCC, Opts);
   ProgCfg.InitialRegYamlFile = Opts.InitialRegisterDataFile;


### PR DESCRIPTION
Fixes #21

Previously, configurations with `honor-target-abi: true` and no `stack`
section failed with "Cannot spill requested registers: no stack space
allocated."

This change automatically enables external stack usage when
`honor-target-abi` is enabled and no internal stack section is provided.

Added a regression test based on the reproducer from the issue.