### PR TITLE
[snippy] Propagate mabi to target machine

### DIFF
--- a/llvm/test/tools/llvm-snippy/mabi-affects-elf-abi.yaml
+++ b/llvm/test/tools/llvm-snippy/mabi-affects-elf-abi.yaml
@@ -1,0 +1,16 @@
+# RUN: llvm-snippy %s -o %t.elf -model-plugin None
+# RUN: llvm-readelf -h %t.elf | FileCheck %s
+
+options:
+  march: rv64gc
+  mtriple: riscv64
+  mabi: lp64d
+
+include:
+  - Inputs/sections.yaml
+
+histogram:
+  - [ADD, 1]
+
+# CHECK: Machine:                           RISC-V
+# CHECK: Flags:                             0x5, RVC, double-float ABI

--- a/llvm/tools/llvm-snippy/include/snippy/GeneratorUtils/LLVMState.h
+++ b/llvm/tools/llvm-snippy/include/snippy/GeneratorUtils/LLVMState.h
@@ -50,6 +50,7 @@ struct SelectedTargetInfo final {
   std::string MArch;
   std::string CPU;
   std::string Features;
+  std::string ABI;
 };
 
 // An object to initialize LLVM and prepare objects needed to run the

--- a/llvm/tools/llvm-snippy/lib/GeneratorUtils/LLVMState.cpp
+++ b/llvm/tools/llvm-snippy/lib/GeneratorUtils/LLVMState.cpp
@@ -154,7 +154,10 @@ Expected<LLVMState> LLVMState::create(const SelectedTargetInfo &TargetInfo) {
 
   TargetFeatures += ",";
   TargetFeatures += TargetInfo.Features;
-  const TargetOptions Options;
+
+  TargetOptions Options;
+  Options.MCOptions.ABIName = TargetInfo.ABI;
+
   auto TM = std::unique_ptr<TargetMachine>(static_cast<TargetMachine *>(
       Tgt->createTargetMachine(TheTriple, TargetInfo.CPU, TargetFeatures,
                                Options, Reloc::Model::Static)));

--- a/llvm/tools/llvm-snippy/llvm-snippy.cpp
+++ b/llvm/tools/llvm-snippy/llvm-snippy.cpp
@@ -170,6 +170,8 @@ static SelectedTargetInfo getSelectedTargetInfo(const ProgramOptions &Opts) {
   TargetInfo.Triple = Opts.MTargetTriple;
   TargetInfo.CPU = Opts.CpuName;
   TargetInfo.Features = Opts.MAttr;
+  TargetInfo.ABI = Opts.ABI;
+
   if (!Opts.MTargetTriple.isSpecified()) {
     TargetInfo.Triple = sys::getProcessTriple();
     if (Opts.MArch.isSpecified())


### PR DESCRIPTION
Fixes #20 

Previously, `mabi` was stored in the configuration and emitted as a module flag,
but it was not propagated to `TargetMachine` creation.

As a result, the generated ELF ABI did not always match the requested `mabi`
unless the corresponding floating-point features were also forced through
`mattr`.

This change passes `mabi` through `TargetOptions::MCOptions.ABIName` when
creating the target machine and adds a regression test that checks the ELF
header flags for `lp64d`.