### PR TITLE
[snippy] implement basic block layout scheme

### DIFF
--- a/llvm/test/tools/llvm-snippy/code-layout/access-size.yaml
+++ b/llvm/test/tools/llvm-snippy/code-layout/access-size.yaml
@@ -1,0 +1,54 @@
+# RUN: llvm-snippy %s -model-plugin None | FileCheck %s
+
+options:
+  mtriple: riscv64
+  dump-bb-addresses: true
+  num-instrs: 100
+
+sections:
+    - name:      1
+      VMA:       0x100000
+      SIZE:      0x20000
+      LMA:       0x100000
+      ACCESS:    rx
+    - name:      2
+      VMA:       0x130000
+      SIZE:      0x20000
+      LMA:       0x130000
+      ACCESS:    rx
+    - name:      4
+      VMA:       0x150000
+      SIZE:      0x100
+      LMA:       0x150000
+      ACCESS:    rx
+    - name:      3
+      VMA:       0x200000
+      SIZE:      0x100000
+      LMA:       0x200000
+      ACCESS:    rw
+ 
+
+code-layout:
+  ranges:
+    - start: 0x100000
+      size: 0x10000
+      stride: 0x10
+      first-offset: 0
+      last-offset: 0
+    - start: 0x130000
+      size: 0x10000
+      stride: 0x10
+      first-offset: 0
+      last-offset: 0
+    - start: 0x150000
+      size: 0x100
+      stride: 0x1
+      first-offset: 0
+      last-offset: 0
+      access-size: 2
+
+histogram:
+    - [ADD, 3.0]
+    - [BLT, 1.0]
+
+# CHECK-NOT:  0x150{{([[:xdigit:]]{3})}}

--- a/llvm/test/tools/llvm-snippy/code-layout/branches-alignment.yaml
+++ b/llvm/test/tools/llvm-snippy/code-layout/branches-alignment.yaml
@@ -1,0 +1,48 @@
+# RUN: not llvm-snippy %s --model-plugin=None |& FileCheck %s
+options:
+  mtriple: riscv64
+  num-instrs: 100
+
+sections:
+    - name:      1
+      VMA:       0x10000
+      SIZE:      0x20000
+      LMA:       0x10000
+      ACCESS:    rx
+    - name:      2
+      VMA:       0x40000
+      SIZE:      0x10000
+      LMA:       0x40000
+      ACCESS:    rw
+code-layout:
+  ranges:
+    - start: 0x10000
+      size: 0x4000
+      stride: 0x10
+      first-offset: 0
+      last-offset: 0
+    - start: 0x20000
+      size: 0x5000
+      stride: 0xD
+      first-offset: 0
+      last-offset: 0
+histogram:
+    - [ADD, 3.0]
+    - [BLT, 1.0]
+branches:
+  permutation: on
+  alignment: 32
+  loop-ratio: 0.5
+  number-of-loop-iterations:
+      min: 2
+      max: 32
+  max-depth:
+    if: 500
+    loop: 4
+  distance:
+    blocks:
+      min: 1
+      max: 20
+
+# CHECK: error
+# CHECK-SAME: Code layout feature is only supported with branches alignment set to 1 

--- a/llvm/test/tools/llvm-snippy/code-layout/code-layout-config.yaml
+++ b/llvm/test/tools/llvm-snippy/code-layout/code-layout-config.yaml
@@ -1,0 +1,40 @@
+# RUN: llvm-snippy %s --model-plugin=None | FileCheck %s
+
+options:
+  mtriple: riscv64
+  num-instrs: 10
+  dump-layout: true
+
+sections:
+    - name:      1
+      VMA:       0x1000
+      SIZE:      0x2000
+      LMA:       0x1000
+      ACCESS:    rx
+    - name:      2
+      VMA:       0x4000
+      SIZE:      0x1000
+      LMA:       0x4000
+      ACCESS:    rw
+    - name:      3
+      VMA:       0x3000
+      SIZE:      0x100
+      LMA:       0x3000
+      ACCESS:    r
+code-layout:
+  ranges:
+    - start: 0x1000
+      size: 0x1500
+      stride: 0x10
+      first-offset: 0
+      last-offset: 0
+
+histogram:
+    - [ADD, 1.0]
+    - [BLT, 1.0]
+
+# CHECK-NOT: unknown key
+# CHECK: code-layout:
+# CHECK-NEXT: ranges:
+# CHECK-DAG: size: 0x1500
+# CHECK-DAG: start: 0x1000

--- a/llvm/test/tools/llvm-snippy/code-layout/code-layout-functions.yaml
+++ b/llvm/test/tools/llvm-snippy/code-layout/code-layout-functions.yaml
@@ -1,0 +1,48 @@
+# RUN: llvm-snippy %s | FileCheck %s
+
+options:
+  mtriple: riscv64-linux-gnu
+  num-instrs: 500
+  redefine-sp: "SP"
+  dump-mf: true
+  function-number: 2
+  num-instr-ancil: 10
+
+sections:
+  - name:      1
+    VMA:       0x210000
+    SIZE:      0x4000000
+    LMA:       0x210000
+    ACCESS:    rx
+  - name:      2
+    VMA:       0x100000
+    SIZE:      0x50000
+    LMA:       0x100000
+    ACCESS:    rw
+  - name:      3
+    VMA:       0x5100000
+    SIZE:      0x50000
+    LMA:       0x510000
+    ACCESS:    r
+  - name:      stack
+    VMA:       0x6500000
+    SIZE:      0x50000
+    LMA:       0x6500000
+    ACCESS:    rw
+
+histogram:
+    - [BNE, 3.0]
+    - [XOR, 1.0]
+    - [JAL, 3.0]
+
+code-layout:
+  ranges:
+    - start: 0x210000
+      size: 0x400000
+      stride: 0x1
+      first-offset: 0
+      last-offset: 0x0
+
+# CHECK: Machine code for function fun0:
+# CHECK: SD $x1, $x2, 0
+# CHECK: $x1 = LD $x2, 0

--- a/llvm/test/tools/llvm-snippy/code-layout/code-layout-gap.yaml
+++ b/llvm/test/tools/llvm-snippy/code-layout/code-layout-gap.yaml
@@ -1,0 +1,36 @@
+# RUN: llvm-snippy %s --model-plugin=None -o %t
+# RUN: llvm-objdump -D -j .snippy.1.rx %t.elf | FileCheck %s
+options:
+  mtriple: riscv64
+  num-instrs: 100
+
+sections:
+    - name:      1
+      VMA:       0x10000
+      SIZE:      0x20000
+      LMA:       0x10000
+      ACCESS:    rx
+    - name:      2
+      VMA:       0x40000
+      SIZE:      0x10000
+      LMA:       0x40000
+      ACCESS:    rw
+code-layout:
+  ranges:
+    - start: 0x10000
+      size: 0x4000
+      stride: 0x10
+      first-offset: 0
+      last-offset: 0
+    - start: 0x20000
+      size: 0x5000
+      stride: 0x10
+      first-offset: 0
+      last-offset: 0
+histogram:
+    - [ADD, 3.0]
+    - [BLT, 1.0]
+
+# CHECK: 000000000000{{([[:xdigit:]]{4})}} <.LBB0_{{[[:digit:]]+}}>
+# CHECK: ...
+# CHECK: 000000000001{{([[:xdigit:]]{4})}} <.LBB0_{{[[:digit:]]+}}>

--- a/llvm/test/tools/llvm-snippy/code-layout/code-layout-loops-calls-error.yaml
+++ b/llvm/test/tools/llvm-snippy/code-layout/code-layout-loops-calls-error.yaml
@@ -1,0 +1,50 @@
+# RUN: not llvm-snippy %s |& FileCheck %s
+
+options:
+  mtriple: riscv64-linux-gnu
+  num-instrs: 10
+  init-regs-in-elf: true
+  function-number: 3
+  function-layers: 1
+  num-instr-ancil: 10
+
+sections:
+  - name:      1
+    VMA:       0x210000
+    SIZE:      0x4000000
+    LMA:       0x210000
+    ACCESS:    rx
+  - name:      2
+    VMA:       0x100000
+    SIZE:      0x50000
+    LMA:       0x100000
+    ACCESS:    rw
+  - name:      3
+    VMA:       0x5100000
+    SIZE:      0x50000
+    LMA:       0x510000
+    ACCESS:    r
+  - name:      stack
+    VMA:       0x6500000
+    SIZE:      0x50000
+    LMA:       0x6500000
+    ACCESS:    rw
+
+histogram:
+    - [BNE, 3.0]
+    - [SUB, 1.0]
+    - [JAL, 3.0]
+
+branches:
+  loop-counters:
+    place-on-stack: off
+
+code-layout:
+  ranges:
+    - start: 0x210000
+      size: 0x400000
+      stride: 0x1
+      first-offset: 0
+      last-offset: 0x0
+
+# CHECK: error: Incompatible options: When code-layout and calls provided, generation of loops without spilling counters is not supported

--- a/llvm/test/tools/llvm-snippy/code-layout/code-layout-loops-calls.yaml
+++ b/llvm/test/tools/llvm-snippy/code-layout/code-layout-loops-calls.yaml
@@ -1,0 +1,63 @@
+# REQUIRES: asserts
+
+# RUN: sed -e s/COMMENTED-CALLS/"#"/g %s | \
+# RUN: sed -e s/"COMMENTED-CL "/""/g > %t.com-calls-uncom-cl.yaml
+# RUN: llvm-snippy %t.com-calls-uncom-cl.yaml -debug \
+# RUN: |& FileCheck %t.com-calls-uncom-cl.yaml --check-prefix=NOT-ON-STACK
+
+# RUN: sed -e s/COMMENTED-CALLS/""/g %s | \
+# RUN: sed -e s/"COMMENTED-CL "/"#"/g > %t.uncom-calls-com-cl.yaml
+# RUN: llvm-snippy %t.uncom-calls-com-cl.yaml -debug \
+# RUN: |& FileCheck %t.uncom-calls-com-cl.yaml --check-prefix=NOT-ON-STACK
+
+# RUN: sed -e s/COMMENTED-CALLS/""/g %s | \
+# RUN: sed -e s/"COMMENTED-CL "/""/g > %t.uncom-calls-uncom-cl.yaml
+# RUN: llvm-snippy %t.uncom-calls-uncom-cl.yaml -debug \
+# RUN: |& FileCheck %t.uncom-calls-uncom-cl.yaml --check-prefix=ON-STACK
+
+options:
+  mtriple: riscv64-linux-gnu
+  num-instrs: 200
+  init-regs-in-elf: true
+  function-number: 3
+  function-layers: 1
+  num-instr-ancil: 10
+
+sections:
+  - name:      1
+    VMA:       0x210000
+    SIZE:      0x4000000
+    LMA:       0x210000
+    ACCESS:    rx
+  - name:      2
+    VMA:       0x100000
+    SIZE:      0x50000
+    LMA:       0x100000
+    ACCESS:    rw
+  - name:      3
+    VMA:       0x5100000
+    SIZE:      0x50000
+    LMA:       0x510000
+    ACCESS:    r
+  - name:      stack
+    VMA:       0x6500000
+    SIZE:      0x50000
+    LMA:       0x6500000
+    ACCESS:    rw
+
+histogram:
+    - [BNE, 3.0]
+    - [SUB, 1.0]
+COMMENTED-CALLS    - [JAL, 3.0]
+
+COMMENTED-CL code-layout:
+COMMENTED-CL   ranges:
+COMMENTED-CL     - start: 0x210000
+COMMENTED-CL       size: 0x400000
+COMMENTED-CL       stride: 0x1
+COMMENTED-CL       first-offset: 0
+COMMENTED-CL       last-offset: 0x0
+
+# NOT-ON-STACK-NOT: place-on-stack: false
+# ON-STACK-DAG: place-on-stack: true
+# ON-STACK-DAG: 'place-on-stack' option for loop counters implicitly enabled: code layout and calls in common require such a behaviour

--- a/llvm/test/tools/llvm-snippy/code-layout/code-layout-many-instrs.yaml
+++ b/llvm/test/tools/llvm-snippy/code-layout/code-layout-many-instrs.yaml
@@ -1,0 +1,59 @@
+# RUN: llvm-snippy %s --model-plugin None -o %t -verify-mi
+# RUN: readelf -S %t.elf | FileCheck %s
+
+options:
+  march: riscv64-unknown-elf
+  mcpu: generic-rv64
+  enable-phdrs-definition: true
+  num-instrs: 1000
+
+sections:
+    - name:      1
+      VMA:       0x100000000
+      SIZE:      0x200000
+      LMA:       0x100000000
+      ACCESS:    rx
+      PHDR:      'header1'
+    - name:      2
+      VMA:       0x15000000
+      SIZE:      0x200000
+      LMA:       0x15000000
+      ACCESS:    rx
+      PHDR:      'header2'
+    - name:      3
+      VMA:       0x1000
+      SIZE:      0x1000
+      LMA:       0x1000
+      ACCESS:    rw
+      PHDR:      'header3'
+    - name:      4
+      VMA:       0x100000
+      SIZE:      0x1000
+      LMA:       0x100000
+      ACCESS:    r
+      PHDR:      'header3'
+
+# About 3.5 Gb between access ranges
+code-layout:
+  ranges:
+    - start: 0x100000000
+      size: 0x200000
+      stride: 0x100000
+      first-offset: 0
+      last-offset: 0xfffff
+    - start: 0x15000000
+      size: 0x200000
+      stride: 0x100000
+      first-offset: 0
+      last-offset: 0xfffff
+histogram:
+    - [ADD, 3.0]
+    - [BLT, 1.0]
+    - [LD,  3.0]
+    - [SW,  3.0]
+
+# CHECK: .snippy.2.rx
+# CHECK-SAME: PROGBITS
+# CHECK: .snippy.1.rx
+# CHECK-SAME: PROGBITS
+

--- a/llvm/test/tools/llvm-snippy/code-layout/code-layout-multiple-rx-sections.yaml
+++ b/llvm/test/tools/llvm-snippy/code-layout/code-layout-multiple-rx-sections.yaml
@@ -1,0 +1,45 @@
+# RUN: llvm-snippy %s --model-plugin None -o %t 
+# RUN: llvm-readelf -S %t.elf | FileCheck %s
+
+options:
+  mtriple: riscv64
+  num-instrs: 200
+
+sections:
+    - name:      1
+      VMA:       0x100000
+      SIZE:      0x20000
+      LMA:       0x100000
+      ACCESS:    rx
+    - name:      2
+      VMA:       0x130000
+      SIZE:      0x200000
+      LMA:       0x130000
+      ACCESS:    rx
+    - name:      3
+      VMA:       0x20000000
+      SIZE:      0x10000000
+      LMA:       0x20000000
+      ACCESS:    rw
+
+code-layout:
+  ranges:
+    - start: 0x100000
+      size: 0x10000
+      stride: 0x10000
+      first-offset: 0
+      last-offset: 0xffff
+    - start: 0x130000
+      size: 0x10000
+      stride: 0x10000
+      first-offset: 0
+      last-offset: 0xffff
+histogram:
+    - [ADD, 3.0]
+    - [BLT, 1.0]
+
+# CHECK: .snippy.1.rx
+# CHECK-SAME: PROGBITS
+# CHECK: .snippy.2.rx
+# CHECK-SAME: PROGBITS
+ 

--- a/llvm/test/tools/llvm-snippy/code-layout/compressed.yaml
+++ b/llvm/test/tools/llvm-snippy/code-layout/compressed.yaml
@@ -1,0 +1,56 @@
+# RUN: llvm-snippy %s -model-plugin None
+
+options:
+  mtriple: riscv64
+  march: rv64ic
+  num-instrs: 100
+  verify-gen-histogram: true
+  histogram-must-succeed: true
+
+sections:
+    - name:      1
+      VMA:       0x10000
+      SIZE:      0x20000
+      LMA:       0x10000
+      ACCESS:    rx
+    - name:      2
+      VMA:       0x40000
+      SIZE:      0x10000
+      LMA:       0x40000
+      ACCESS:    rw
+code-layout:
+  ranges:
+    - start: 0x10000
+      size: 0x4000
+      stride: 0x10
+      first-offset: 0
+      last-offset: 0
+    - start: 0x20000
+      size: 0x5000
+      stride: 0xD
+      first-offset: 0
+      last-offset: 0
+histogram:
+    - [ADD, 3.0]
+    - [BLT, 1.0]
+    - [BEQ, 2.0]
+    - [BLT, 2.0]
+    - [BGE, 2.0]
+    - [BNE, 2.0]
+    - [C_BEQZ, 2.0]
+    - [C_BNEZ, 2.0]
+
+branches:
+  permutation: on
+  loop-ratio: 0.5
+  number-of-loop-iterations:
+      min: 2
+      max: 32
+  max-depth:
+    if: 500
+    loop: 4
+  distance:
+    blocks:
+      min: 1
+      max: 20
+

--- a/llvm/test/tools/llvm-snippy/code-layout/dest-symbol.yaml
+++ b/llvm/test/tools/llvm-snippy/code-layout/dest-symbol.yaml
@@ -1,0 +1,50 @@
+# RUN: llvm-snippy %s -model-plugin None -o %t
+# RUN: readelf -s --wide %t.elf | FileCheck %s
+
+options:
+  mtriple: riscv64
+  enable-phdrs-definition: true
+  num-instrs: 50
+
+sections:
+    - name:      1
+      VMA:       0x100000
+      SIZE:      0x1000
+      LMA:       0x100000
+      ACCESS:    rx
+      PHDR:      'header1'
+    - name:      2
+      VMA:       0x15000
+      SIZE:      0x1000
+      LMA:       0x15000
+      ACCESS:    rx
+      PHDR:      'header2'
+    - name:      3
+      VMA:       0x1000
+      SIZE:      0x1000
+      LMA:       0x1000
+      ACCESS:    rw
+      PHDR:      'header3'
+    - name:      4
+      VMA:       0x1000000
+      SIZE:      0x1000
+      LMA:       0x1000000
+      ACCESS:    r
+      PHDR:      'header3'
+
+code-layout:
+  ranges:
+    - start: 0x100000
+      size: 0x1000
+      stride: 0x8
+      first-offset: 0
+      last-offset: 0
+    - start: 0x15000
+      size: 0x1000
+      stride: 0x8
+      first-offset: 0
+      last-offset: 0
+histogram:
+    - [BLT, 1.0]
+
+# CHECK-COUNT-50: .dest

--- a/llvm/test/tools/llvm-snippy/code-layout/linker-test-large.yaml
+++ b/llvm/test/tools/llvm-snippy/code-layout/linker-test-large.yaml
@@ -1,0 +1,17 @@
+# RUN: llvm-snippy %S/code-layout-many-instrs.yaml \
+# RUN:   --model-plugin None -o %t
+
+# RUN: ld.lld %t.elf -T %t.ld -o %t.final.elf
+
+# RUN: llvm-readobj -S %t.final.elf  --elf-output-style JSON | \ 
+# RUN: %python %S/Inputs/get_section_size.py .snippy.1.rx  > %t.rx1
+
+# RUN: llvm-readobj -S %t.final.elf  --elf-output-style JSON | \ 
+# RUN: %python %S/Inputs/get_section_size.py .snippy.2.rx > %t.rx2
+
+# Check that both rx sections are not empty
+# RUN: cat %t.rx1 | awk '{print $0 >= 1000}' | grep 1
+# RUN: cat %t.rx2 | awk '{print $0 >= 1000}' | grep 1
+
+# Check that file's size is less than 0.5 Gb
+# RUN: stat -c %s %t.final.elf | awk '{print $0 <= 1024*1024*1024}' | grep 1

--- a/llvm/test/tools/llvm-snippy/code-layout/linker-test.yaml
+++ b/llvm/test/tools/llvm-snippy/code-layout/linker-test.yaml
@@ -1,0 +1,23 @@
+# RUN: llvm-snippy %S/code-layout-multiple-rx-sections.yaml \
+# RUN:   --model-plugin None -o %t
+
+
+# RUN: ld.lld %t.elf -T %t.ld -o %t.final.elf
+
+# RUN: llvm-readobj -S %t.final.elf  --elf-output-style JSON | \ 
+# RUN: %python %S/Inputs/get_section_size.py .snippy.1.rx  > %t.rx1
+# RUN: llvm-readobj -S %t.final.elf  --elf-output-style JSON | \ 
+# RUN: %python %S/Inputs/get_section_size.py .snippy.2.rx > %t.rx2
+
+# Check that both rx sections are not empty
+# RUN: cat %t.rx1 | awk '{print $0 >= 1000}' | grep 1
+# RUN: cat %t.rx2 | awk '{print $0 >= 1000}' | grep 1
+
+# We expect to see at least 5 BBs in each rx section
+# RUN: llvm-objdump -D %t.final.elf | FileCheck %s
+
+# CHECK: 100000 <.snippy.1.rx>:
+# CHECK-COUNT-5: <.LBB0_{{([[:digit:]]+)}}>:
+# CHECK: 130000 <.snippy.2.rx>
+# CHECK-COUNT-5: <.LBB0_{{([[:digit:]]+)}}>:
+

--- a/llvm/test/tools/llvm-snippy/code-layout/multiple-functions.yaml
+++ b/llvm/test/tools/llvm-snippy/code-layout/multiple-functions.yaml
@@ -1,0 +1,50 @@
+# RUN: llvm-snippy %s -model-plugin None | FileCheck %s
+
+options:
+  mtriple: riscv64
+  num-instrs: 300
+  dump-mf: true
+  function-number: 20
+sections:
+    - name:      1
+      VMA:       0x100000
+      SIZE:      0x50000
+      LMA:       0x100000
+      ACCESS:    rx
+    - name:      2
+      VMA:       0x150000
+      SIZE:      0x70000
+      LMA:       0x150000
+      ACCESS:    rx
+    - name:      3
+      VMA:       0x220000
+      SIZE:      0x100000
+      LMA:       0x220000
+      ACCESS:    rw
+    - name:      stack
+      VMA:       0x400000
+      LMA:       0x400000
+      SIZE:      0x1000
+      ACCESS:    rw
+ 
+
+code-layout:
+  ranges:
+    - start: 0x100000
+      size: 0x50000
+      stride: 0x10
+      first-offset: 0
+      last-offset: 0
+    - start: 0x150000
+      size: 0x70000
+      stride: 0x10
+      first-offset: 0
+      last-offset: 0
+histogram:
+    - [ADD, 3.0]
+    - [BLT, 1.0]
+    - [LD,  3.0]
+    - [SW,  3.0]
+    - [JAL, 1.0]
+
+# CHECK: PseudoCALL

--- a/llvm/test/tools/llvm-snippy/code-layout/scheme-outside-of-sections-warn.yaml
+++ b/llvm/test/tools/llvm-snippy/code-layout/scheme-outside-of-sections-warn.yaml
@@ -1,0 +1,46 @@
+# RUN: llvm-snippy %s --model-plugin=None -o %t |& FileCheck %s
+# RUN: llvm-objdump -D -j .snippy.1.rx %t.elf | FileCheck %s --check-prefix OBJ
+options:
+  mtriple: riscv64
+  num-instrs: 20
+
+sections:
+    - name:      1
+      VMA:       0x10000
+      SIZE:      0x20000
+      LMA:       0x10000
+      ACCESS:    rx
+    - name:      2
+      VMA:       0x3000
+      SIZE:      0x1000
+      LMA:       0x3000
+      ACCESS:    rw
+
+code-layout:
+  ranges:
+    - start: 0x10000
+      size: 0x20000
+      stride: 0x10
+      first-offset: 0
+      last-offset: 0
+    - start: 0x0
+      size: 0x10
+      stride: 0x10
+      first-offset: 0
+      last-offset: 0xf
+
+histogram:
+    - [ADD, 1.0]
+    - [BLT, 1.0]
+
+# CHECK: warning: (memory-access) Possibly wrong code layout:
+# CHECK-SAME: Following scheme permits code generation outside of all RX sections
+# CHECK: access-ranges:
+# CHECK-NEXT:   - weight:          1
+# CHECK-NEXT:     start:           0x0
+# CHECK-NEXT:     size:            0x10
+# CHECK-NEXT:     stride:          0x10
+# CHECK-NEXT:     first-offset:    0
+# CHECK-NEXT:     last-offset:     0xF
+
+# OBJ-NOT: 000000000300{{[01]([[:xdigit:]]{3})}}

--- a/llvm/tools/llvm-snippy/docs/index.rst
+++ b/llvm/tools/llvm-snippy/docs/index.rst
@@ -1680,6 +1680,8 @@ Advanced configuration includes keys for:
 
 -  `Call graph <#call-graph>`__
 
+-  `Basic block layout <#basic-block-layout>`__
+
 
 -  `Register Reservation Config`_
 
@@ -1835,6 +1837,52 @@ instructions. For the details on vector register grouping, refer
 
 .. note::
    Even if you reserve only one register from the vector group, the whole register group is reserved for the respective instructions.
+
+Basic Block Layout
+------------------
+
+Use the ``code-layout`` key in your layout to configure a specific range
+of addresses for basic blocks to be put in.
+
+Via ``code-layout``, you provide memory address ranges where you want
+basic blocks to be replaced by the linker in the generated snippet. All
+the basic blocks in the generated snippet are then randomly placed in
+memory addresses that correspond to these ranges. Configuration of the
+``code-layout`` schemes is similar to the configuration of
+``access-ranges`` in `memory schemes <#memory-scheme>`__.
+
+Address ranges can reference memory from different RX section. For
+example, it makes possible code distribution between different RX
+sections.
+
+An example of ``code-layout``:
+
+.. code:: yaml
+
+   code-layout:
+     ranges:
+       - start: 0x10000
+         size: 0x2000
+         stride: 0x20
+         first-offset: 0
+         last-offset: 0
+       - start: 0x13000
+         size: 0x2000
+         stride: 0x20
+         first-offset: 0
+         last-offset: 0
+
+where:
+
+-  ``start`` |nbsp| -- |nbsp| Section start address.
+
+-  ``size`` |nbsp| -- |nbsp| Section size.
+
+-  ``stride`` |nbsp| -- |nbsp| Stride size.
+
+-  ``first offset`` |nbsp| -- |nbsp| Number of the first available bit in a stride.
+
+-  ``last offset`` |nbsp| -- |nbsp| Number of the last available bit in a stride.
 
 
 Control Flow (Branchegrams)

--- a/llvm/tools/llvm-snippy/include/snippy/Config/Config.h
+++ b/llvm/tools/llvm-snippy/include/snippy/Config/Config.h
@@ -198,6 +198,7 @@ struct InstrsGenerationOptions {
   bool RunMachineInstrVerifier;
   bool ChainedRXSectionsFill;
   bool ChainedRXSorted;
+  bool NeedsRelocations;
   std::optional<unsigned> ChainedRXChunkSize;
   std::optional<unsigned> NumInstrs;
   std::string LastInstr;
@@ -238,6 +239,7 @@ public:
   // Function generator pass config.
   std::variant<CallGraphLayout, FunctionDescs> CGLayout;
 
+  std::optional<CodeLayoutConfig> CodeLayout;
   TraceConvertOptions TFOpts;
   PassConfig(const ProgramConfig &ProgramCfg) : ProgramCfg(&ProgramCfg) {}
 

--- a/llvm/tools/llvm-snippy/include/snippy/Config/MemoryScheme.h
+++ b/llvm/tools/llvm-snippy/include/snippy/Config/MemoryScheme.h
@@ -792,6 +792,10 @@ void diagnoseXSections(LLVMContext &Ctx, SecIt SectionsStart, SecIt SectionsFin,
   }
 }
 
+struct CodeLayoutConfig final {
+  std::vector<MemoryAccessRange> Ranges;
+};
+
 class MemoryScheme {
 public:
   MemoryAccessSeq BaseAccesses;
@@ -842,4 +846,5 @@ LLVM_SNIPPY_YAML_DECLARE_SEQUENCE_TRAITS(snippy::SectionsDescriptions,
 
 LLVM_SNIPPY_YAML_DECLARE_MAPPING_TRAITS(snippy::MemoryScheme);
 
+LLVM_SNIPPY_YAML_DECLARE_MAPPING_TRAITS_WITH_VALIDATE(snippy::CodeLayoutConfig);
 } // namespace llvm

--- a/llvm/tools/llvm-snippy/include/snippy/CreatePasses.h
+++ b/llvm/tools/llvm-snippy/include/snippy/CreatePasses.h
@@ -95,4 +95,17 @@ MachineFunctionPass *createRISCVExpandSnippyPseudoPass();
 
 MachineFunctionPass *createRISCVZcmpPopretCombinePass();
 
+MachineFunctionPass *createCLBasicBlockPreprocessPass();
+
+MachineFunctionPass *createCodeAddrSamplingPass();
+
+MachineFunctionPass *createFallThroughEraserPass();
+
+MachineFunctionPass *createBranchLengthenerPass();
+
+snippy::ActiveImmutablePassInterface *createJumpLengthenerPass();
+
+MachineFunctionPass *createLongJumpRelaxatorPass();
+
+MachineFunctionPass *createLinkerConfigurePass();
 } // namespace llvm

--- a/llvm/tools/llvm-snippy/include/snippy/Generator/CodeAddrSampler.h
+++ b/llvm/tools/llvm-snippy/include/snippy/Generator/CodeAddrSampler.h
@@ -1,0 +1,33 @@
+//===-- CodeAddrSampler.h ---------------------------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_SNIPPY_INCLUDE_GENERATOR_CODE_ADDR_SAMPLER_H
+#define LLVM_SNIPPY_INCLUDE_GENERATOR_CODE_ADDR_SAMPLER_H
+
+#include "snippy/Config/MemoryScheme.h"
+#include "snippy/Generator/RandomMemAccSampler.h"
+
+namespace llvm {
+namespace snippy {
+
+/// \brief Class to randomly sample code sections addresses according to the
+/// immutable CodeLayout configuration. Unlike MemoryScheme it samples addresses
+/// from RX sections
+class CodeAddrSampler : private RandomMemoryAccessSampler {
+public:
+  CodeAddrSampler(const CodeLayoutConfig &Config,
+                  const SectionsDescriptions &Sections,
+                  Align Alignment);
+
+  AddressInfo randomAddress(const AddressGenInfo &Params);
+  using RandomMemoryAccessSampler::print;
+};
+
+} // namespace snippy
+} // namespace llvm
+#endif

--- a/llvm/tools/llvm-snippy/include/snippy/Generator/CodeAddrSamplingPass.h
+++ b/llvm/tools/llvm-snippy/include/snippy/Generator/CodeAddrSamplingPass.h
@@ -1,0 +1,37 @@
+//===-- CodeAddrSamplingPass.h ----------------------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_SNIPPY_INCLUDE_GENERATOR_CODE_ADDR_SAMPLING_PASS_H
+#define LLVM_SNIPPY_INCLUDE_GENERATOR_CODE_ADDR_SAMPLING_PASS_H
+
+#include "llvm/CodeGen/MachineFunctionPass.h"
+
+namespace llvm {
+namespace snippy {
+
+class PassConfig;
+
+class CodeAddrSampling final : public MachineFunctionPass {
+
+public:
+  static char ID;
+
+  CodeAddrSampling() : MachineFunctionPass(ID) {}
+
+  StringRef getPassName() const override {
+    return "Snippy Code Addresses Sampling Pass";
+  }
+
+  void getAnalysisUsage(AnalysisUsage &AU) const override;
+
+  bool runOnMachineFunction(MachineFunction &MF) override;
+};
+
+} // namespace snippy
+} // namespace llvm
+#endif

--- a/llvm/tools/llvm-snippy/include/snippy/Generator/FallThroughsEraserPass.h
+++ b/llvm/tools/llvm-snippy/include/snippy/Generator/FallThroughsEraserPass.h
@@ -1,0 +1,32 @@
+//===-- FallThroughsEraserPass.h --------------------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_SNIPPY_INCLUDE_GENERATOR_FALLTHROUGH_ERASER_PASS_H
+#define LLVM_SNIPPY_INCLUDE_GENERATOR_FALLTHROUGH_ERASER_PASS_H
+
+#include "llvm/CodeGen/MachineFunctionPass.h"
+namespace llvm {
+namespace snippy {
+
+class FallThroughEraserPass final : public MachineFunctionPass {
+
+public:
+  static char ID;
+
+  FallThroughEraserPass() : MachineFunctionPass(ID) {}
+
+  StringRef getPassName() const override { return "Fall Through Eraser Pass"; }
+
+  void getAnalysisUsage(AnalysisUsage &AU) const override;
+
+  bool runOnMachineFunction(MachineFunction &MF) override;
+};
+
+} // namespace snippy
+} // namespace llvm
+#endif

--- a/llvm/tools/llvm-snippy/include/snippy/Generator/IndJumpInfo.h
+++ b/llvm/tools/llvm-snippy/include/snippy/Generator/IndJumpInfo.h
@@ -1,0 +1,53 @@
+//===-- IndJumpInfo.h -------------------------------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_SNIPPY_INCLUDE_GENERATOR_IND_JUMP_INFO_H
+#define LLVM_SNIPPY_INCLUDE_GENERATOR_IND_JUMP_INFO_H
+
+#include "llvm/ADT/DenseMap.h"
+#include "llvm/CodeGen/MachineBasicBlock.h"
+
+namespace llvm {
+namespace snippy {
+
+struct IndJumpInfo final {
+  MachineBasicBlock *MBB;
+  std::vector<MachineInstr *> Support;
+};
+
+class IndJumpInfoMap final
+    : private DenseMap<const MachineInstr *, IndJumpInfo> {
+public:
+  void addJump(const MachineInstr &Jump, IndJumpInfo Dst) {
+    auto [It, WasInserted] = DenseMap::try_emplace(&Jump, std::move(Dst));
+    assert(WasInserted && "Attempt to specify destination for jump twice");
+  }
+
+  void remove(const MachineInstr &Jump) {
+    auto Removed = DenseMap::erase(&Jump);
+    assert(Removed);
+  }
+
+  auto &getInfo(const MachineInstr &Jump) const & {
+    auto Found = DenseMap::find(&Jump);
+    assert(Found != end() && "Attempt to get Destination for unknown jump");
+    return Found->second;
+  }
+
+  bool contains(const MachineInstr &Jump) const {
+    return DenseMap::count(&Jump);
+  }
+
+  using DenseMap::empty;
+  using DenseMap::size;
+};
+
+} // namespace snippy
+} // namespace llvm
+
+#endif

--- a/llvm/tools/llvm-snippy/include/snippy/Generator/JumpLengthenerPass.h
+++ b/llvm/tools/llvm-snippy/include/snippy/Generator/JumpLengthenerPass.h
@@ -1,0 +1,35 @@
+//===-- JumpLengthenerPass.h ------------------------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#pragma once
+
+#include "snippy/ActiveImmutablePass.h"
+#include "snippy/Generator/IndJumpInfo.h"
+#include "llvm/CodeGen/MachineFunctionPass.h"
+
+namespace llvm {
+namespace snippy {
+
+class JumpLengthener final
+    : public ActiveImmutablePass<MachineFunctionPass, IndJumpInfoMap> {
+  bool runOnMachineBasicBlock(MachineBasicBlock &MBB, IndJumpInfoMap &JumpMap);
+
+public:
+  static char ID;
+
+  JumpLengthener() : ActiveImmutablePass(ID) {}
+
+  StringRef getPassName() const override;
+
+  void getAnalysisUsage(AnalysisUsage &AU) const override;
+
+  bool runOnMachineFunction(MachineFunction &MF) override;
+};
+
+} // namespace snippy
+} // namespace llvm

--- a/llvm/tools/llvm-snippy/include/snippy/Generator/Linker.h
+++ b/llvm/tools/llvm-snippy/include/snippy/Generator/Linker.h
@@ -41,6 +41,7 @@ public:
 
   struct InputSection final {
     std::string Name;
+    std::optional<AddressInfo> Addr = std::nullopt;
   };
 
   struct SectionEntry {
@@ -53,6 +54,7 @@ public:
   };
 
   class LinkedSections final : private std::vector<SectionEntry> {
+    std::unordered_map<std::string, MemAddr> SectToAddrMap;
     auto getSectionImpl(StringRef Name) const {
       return std::find_if(begin(), end(), [Name](const auto &E) {
         return E.OutputSection.Name == Name;
@@ -113,6 +115,13 @@ public:
     }
 
     void addInputSectionFor(const SectionDesc &OutDesc, StringRef InSectName);
+    void addInputSection(StringRef Name, AddressInfo AI);
+
+    MemAddr getAddressFor(StringRef Name) const;
+
+    bool hasAddressFor(StringRef Name) const {
+      return SectToAddrMap.count(Name.str());
+    }
   };
 
   explicit Linker(LLVMContext &Ctx, const SectionsDescriptions &Sects,

--- a/llvm/tools/llvm-snippy/include/snippy/Generator/SnippyModule.h
+++ b/llvm/tools/llvm-snippy/include/snippy/Generator/SnippyModule.h
@@ -52,6 +52,7 @@ class OpcodeCache;
 class MemoryManager;
 class ProgramConfig;
 class RootRegPoolWrapper;
+class CodeAddrSampler;
 
 struct ObjectFile final {
   SmallString<32> Object;
@@ -238,6 +239,8 @@ public:
     return getOutputSectionFor(F);
   }
 
+  CodeAddrSampler &getOrCreateAddrSampler(const PassConfig &Cfg);
+
   bool isManglingEnabled() const { return MangleExportedNames; }
 
   auto hasSelfcheckSections() const { return SelfcheckSection.has_value(); }
@@ -359,6 +362,7 @@ private:
   std::unique_ptr<ProgramGlobalStateKeeper> PGSK;
   std::map<Module *, std::unique_ptr<GlobalsPool>> PerModuleGPs;
   std::unique_ptr<TargetGenContextInterface> TargetContext;
+  std::unique_ptr<CodeAddrSampler> PSampler;
   std::unique_ptr<StaticStackContext> StaticStack;
 
   MCRegister StackPointer;

--- a/llvm/tools/llvm-snippy/include/snippy/Support/DiagnosticInfo.h
+++ b/llvm/tools/llvm-snippy/include/snippy/Support/DiagnosticInfo.h
@@ -48,7 +48,8 @@ namespace snippy {
   WARN_CASE(NonReproducibleExecution, "non-reproducible-execution")            \
   WARN_CASE(MArchIsTriple, "march-is-triple")                                  \
   WARN_CASE(CannotGenerateCalls, "cannot-generate-calls")                      \
-  WARN_CASE(OperandsReinitialization, "operands-reinitialization")
+  WARN_CASE(OperandsReinitialization, "operands-reinitialization")             \
+  WARN_CASE(LoopCountersOnStack, "loop-counters-on-stack")
 
 #ifdef WARN_CASE
 #error WARN_CASE should not be defined at this point

--- a/llvm/tools/llvm-snippy/include/snippy/Support/Options.h
+++ b/llvm/tools/llvm-snippy/include/snippy/Support/Options.h
@@ -405,7 +405,7 @@ Error diagnoseIfOptionAndOptionalAreBothSet(const std::optional<T> &Val,
 
 struct RegexOption {
   std::string Str;
-  std::shared_ptr<Regex> Regex;
+  std::shared_ptr<Regex> RegexPtr;
 };
 
 } // namespace snippy

--- a/llvm/tools/llvm-snippy/include/snippy/Target/Target.h
+++ b/llvm/tools/llvm-snippy/include/snippy/Target/Target.h
@@ -464,6 +464,8 @@ public:
 
   virtual bool replaceBranchDest(MachineInstr &Branch,
                                  MachineBasicBlock &NewDestMBB) const = 0;
+  virtual bool replaceBranchDest(MachineInstr &Branch,
+                                 MachineBasicBlock::iterator To) const = 0;
 
   virtual bool replaceBranchDest(MachineBasicBlock &BranchMBB,
                                  MachineBasicBlock &OldDestMBB,
@@ -663,10 +665,16 @@ public:
   virtual std::unique_ptr<AsmPrinter>
   createAsmPrinter(TargetMachine &TM,
                    std::unique_ptr<MCStreamer> Streamer) const = 0;
+  virtual MachineBasicBlock::iterator
+  insertJumpThroughRelocation(InstructionGenerationContext &IGC,
+                              uint64_t Addr) const = 0;
 
   virtual MachineBasicBlock::iterator
   generateJump(MachineBasicBlock &MBB, MachineBasicBlock::iterator Ins,
                MachineBasicBlock &TBB, LLVMState &State) const = 0;
+  virtual bool fitsCondBranch(uint64_t Distance) const = 0;
+
+  virtual bool fitsUncondBranch(uint64_t Distance) const = 0;
 
   // Add any additional target-dependent flags to provide additional information
   // to asm printer.

--- a/llvm/tools/llvm-snippy/lib/BranchLengthenerPass.cpp
+++ b/llvm/tools/llvm-snippy/lib/BranchLengthenerPass.cpp
@@ -1,0 +1,108 @@
+//===-- JumpLengthenerPass.cpp ----------------------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "snippy/CreatePasses.h"
+#include "snippy/Generator/GenerationUtils.h"
+#include "snippy/Generator/GeneratorContextPass.h"
+
+#include "InitializePasses.h"
+
+#include "llvm/CodeGen/MachineFunctionPass.h"
+
+#define DEBUG_TYPE "snippy-branch-lengthener"
+#define PASS_DESC "Snippy Branch Lengthener"
+
+namespace llvm {
+namespace snippy {
+namespace {
+class BranchLengthener final : public MachineFunctionPass {
+  bool runOnMachineBasicBlock(MachineBasicBlock &MBB) const;
+
+public:
+  static char ID;
+
+  BranchLengthener() : MachineFunctionPass(ID) {}
+
+  StringRef getPassName() const override;
+
+  void getAnalysisUsage(AnalysisUsage &AU) const override;
+
+  bool runOnMachineFunction(MachineFunction &MF) override;
+};
+} // namespace
+char BranchLengthener::ID = 0;
+} // namespace snippy
+} // namespace llvm
+
+using llvm::callDefaultCtor;
+using llvm::PassInfo;
+using llvm::PassRegistry;
+using llvm::snippy::BranchLengthener;
+
+INITIALIZE_PASS_BEGIN(BranchLengthener, DEBUG_TYPE, PASS_DESC, false, false)
+INITIALIZE_PASS_DEPENDENCY(GeneratorContextWrapper)
+INITIALIZE_PASS_END(BranchLengthener, DEBUG_TYPE, PASS_DESC, false, false)
+
+namespace llvm {
+namespace snippy {
+
+StringRef BranchLengthener::getPassName() const { return PASS_DESC " Pass"; }
+
+void BranchLengthener::getAnalysisUsage(AnalysisUsage &AU) const {
+  AU.setPreservesCFG();
+  AU.addRequired<GeneratorContextWrapper>();
+  MachineFunctionPass::getAnalysisUsage(AU);
+}
+
+static void lengthenBranch(MachineInstr &Br, MachineBasicBlock &MBB,
+                           GeneratorContext &GC, const SnippyTarget &Tgt) {
+  auto *BrDest = Tgt.getBranchDestination(Br);
+  assert(BrDest);
+  auto &ProgCtx = GC.getProgramContext();
+  auto &State = ProgCtx.getLLVMState();
+  Tgt.insertFallbackBranch(MBB, *BrDest, State);
+  auto &InsertedJump = MBB.back();
+
+  auto *Symbol =
+      State.getMCContext().getOrCreateSymbol(getMBBSectionName(MBB) + ".dest");
+  assert(Symbol);
+  auto *MFPtr = MBB.getParent();
+  assert(MFPtr);
+  auto &MF = *MFPtr;
+  InsertedJump.setPreInstrSymbol(MF, Symbol);
+  Tgt.replaceBranchDest(Br, InsertedJump);
+}
+
+bool BranchLengthener::runOnMachineBasicBlock(MachineBasicBlock &MBB) const {
+  auto &GC = getAnalysis<GeneratorContextWrapper>().getContext();
+  auto &ProgCtx = GC.getProgramContext();
+  auto &Tgt = ProgCtx.getLLVMState().getSnippyTarget();
+  auto FirstTermIt = MBB.getFirstTerminator();
+  if (FirstTermIt == MBB.end())
+    return false;
+  auto &FirstTerm = *FirstTermIt;
+  if (!FirstTerm.isConditionalBranch())
+    return false;
+  lengthenBranch(FirstTerm, MBB, GC, Tgt);
+  return true;
+}
+
+bool BranchLengthener::runOnMachineFunction(MachineFunction &MF) {
+  bool Changed = false;
+  for (auto &MBB : MF)
+    Changed |= runOnMachineBasicBlock(MBB);
+  return Changed;
+}
+
+} // namespace snippy
+
+MachineFunctionPass *createBranchLengthenerPass() {
+  return new snippy::BranchLengthener;
+}
+
+} // namespace llvm

--- a/llvm/tools/llvm-snippy/lib/CMakeLists.txt
+++ b/llvm/tools/llvm-snippy/lib/CMakeLists.txt
@@ -29,12 +29,14 @@ set(LLVM_LINK_COMPONENTS
   SnippyGenerator
   )
 set(LLVMSnippySources
+  BranchLengthenerPass.cpp
   BranchRelaxatorPass.cpp
   BlockGenPlanningPass.cpp
   BlockGenPlanWrapperPass.cpp
   PreserveRegsInsertionPass.cpp
   CFGeneratorPass.cpp
   CFGPrinter.cpp
+  ConfigureLinkerPass.cpp
   ConsecutiveLoopsVerifierPass.cpp
   FillExternalFunctionsStubsPass.cpp
   FlowGenerator.cpp

--- a/llvm/tools/llvm-snippy/lib/Config/Config.cpp
+++ b/llvm/tools/llvm-snippy/lib/Config/Config.cpp
@@ -664,6 +664,20 @@ static std::vector<std::string> parseModelPluginList(const ModelOptions &Opts) {
   return Ret;
 }
 
+static bool codeLayoutIsBig(const CodeLayoutConfig &CodeLayout,
+                            const SnippyTarget &Tgt) {
+  auto &Addresses = CodeLayout.Ranges;
+  assert(!Addresses.empty());
+  auto Starts = llvm::map_range(Addresses, [](auto &R) { return R.Start; });
+  auto MinStart = *std::min_element(Starts.begin(), Starts.end());
+  auto Finishes =
+      llvm::map_range(Addresses, [](auto &R) { return R.Start + R.Size; });
+  auto MaxFinish = *std::max_element(Finishes.begin(), Finishes.end());
+  assert(MaxFinish > MinStart);
+  auto MaxDist = MaxFinish - MinStart;
+  return !Tgt.fitsUncondBranch(MaxDist);
+}
+
 static unsigned long long
 seedOptToValue(StringRef SeedStr, StringRef SeedType = "instructions seed",
                StringRef Warning =
@@ -811,6 +825,22 @@ static void normalizeProgramLevelOptions(Config &Cfg, LLVMState &State,
     DEBUG_WITH_TYPE("snippy-regpool",
                     (dbgs() << "Reserved with option:\n", RP.print(dbgs())));
   }
+  if (Cfg.PassCfg.CodeLayout) {
+    auto HasCalls = Cfg.Histogram.hasCallInstrs(OpCC, Tgt);
+    if (HasCalls) {
+      if (!Cfg.PassCfg.Branches.LoopCounters.UseStack.has_value()) {
+        Cfg.PassCfg.Branches.LoopCounters.UseStack = true;
+        snippy::warn(
+            WarningName::LoopCountersOnStack, Ctx,
+            "'place-on-stack' option for loop counters implicitly enabled",
+            "code layout and calls in common require such a behaviour");
+      } else if (!Cfg.PassCfg.Branches.LoopCounters.UseStack.value()) {
+        snippy::fatal("Incompatible options",
+                      "When code-layout and calls provided, generation of "
+                      "loops without spilling counters is not supported");
+      }
+    }
+  }
   auto RegsSpilledToStack = parseSpilledRegistersOption(RP, Tgt, RI, Ctx, Opts);
   auto RegsSpilledToMem = getRegsToSpillToMem(Tgt, Cfg);
   bool HasSPRelativeInstrs = Cfg.Histogram.hasSPRelativeInstrs(OpCC, Tgt);
@@ -905,6 +935,10 @@ static Error normalizeInstrGenOptions(Config &Cfg, LLVMState &State,
     snippy::warn(WarningName::InconsistentOptions, State.getCtx(),
                  "'" + Twine(ChainedRXChunkSize.ArgStr) + "' is ignored",
                  "pass 'chained-rx-sections-fill' to enable it");
+  bool MayNeedRelocatedJumps =
+      PassCfg.CodeLayout &&
+      codeLayoutIsBig(*PassCfg.CodeLayout, State.getSnippyTarget());
+  InstrsCfg.NeedsRelocations = MayNeedRelocatedJumps;
   InstrsCfg.NumInstrs = NumPrimaryInstrs;
   InstrsCfg.LastInstr = Opts.LastInstr;
 
@@ -1021,6 +1055,7 @@ void yaml::MappingTraits<Config>::mapping(yaml::IO &IO, Config &Info) {
 
   Info.ProgramCfg.TargetConfig->mapConfig(IO);
   IO.mapOptional("fpu-config", Info.CommonPolicyCfg->FPUConfig);
+  IO.mapOptional("code-layout", Info.PassCfg.CodeLayout);
   IO.mapOptional("operands-reinitialization",
                  Info.DefFlowConfig.OperandsReinitialization);
   MappingNormalization<RegisterAccessNormalization, RegisterAccessConfig>
@@ -1029,6 +1064,11 @@ void yaml::MappingTraits<Config>::mapping(yaml::IO &IO, Config &Info) {
 }
 
 std::string yaml::MappingTraits<Config>::validate(yaml::IO &Io, Config &Info) {
+  if (Info.PassCfg.CodeLayout && !Info.PassCfg.Branches.unaligned())
+    return Twine("Code layout feature is only supported with branches "
+                 "alignment set to ")
+        .concat(Twine(Branchegram::Unaligned))
+        .str();
   void *Ctx = Io.getContext();
   assert(Ctx && "To parse or output Config provide ConfigIOContext as "
                 "context for yaml::IO");

--- a/llvm/tools/llvm-snippy/lib/Config/MemoryScheme.cpp
+++ b/llvm/tools/llvm-snippy/lib/Config/MemoryScheme.cpp
@@ -1248,6 +1248,18 @@ yaml::SequenceTraits<snippy::SectionsDescriptions>::element(
   return Sections.at(Index);
 }
 
+void yaml::MappingTraits<snippy::CodeLayoutConfig>::mapping(
+    yaml::IO &IO, snippy::CodeLayoutConfig &Info) {
+  IO.mapRequired("ranges", Info.Ranges);
+}
+
+std::string yaml::MappingTraits<snippy::CodeLayoutConfig>::validate(
+    yaml::IO &IO, snippy::CodeLayoutConfig &Addrs) {
+  if (Addrs.Ranges.empty())
+    return "Code address ranges should not be empty";
+  return "";
+}
+
 using snippy::AccMask;
 void yaml::ScalarTraits<AccMask>::output(const AccMask &Val, void *,
                                          raw_ostream &Out) {

--- a/llvm/tools/llvm-snippy/lib/ConfigureLinkerPass.cpp
+++ b/llvm/tools/llvm-snippy/lib/ConfigureLinkerPass.cpp
@@ -1,0 +1,78 @@
+//===-- ConfigureLinkerPass.cpp ---------------------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "InitializePasses.h"
+#include "snippy/CreatePasses.h"
+#include "snippy/Generator/FunctionGeneratorPass.h"
+#include "snippy/Generator/GeneratorContextPass.h"
+
+#define DEBUG_TYPE "snippy-configure-linker"
+#define PASS_DESC "Snippy Configure Linker"
+
+namespace llvm {
+namespace snippy {
+namespace {
+
+class ConfigureLinker final : public MachineFunctionPass {
+public:
+  static char ID;
+
+  ConfigureLinker() : MachineFunctionPass(ID) {}
+
+  StringRef getPassName() const override { return PASS_DESC " Pass"; }
+
+  bool runOnMachineFunction(MachineFunction &MF) override;
+
+  void getAnalysisUsage(AnalysisUsage &AU) const override {
+    AU.addRequired<GeneratorContextWrapper>();
+    AU.addRequired<FunctionGenerator>();
+    MachineFunctionPass::getAnalysisUsage(AU);
+  }
+};
+
+char ConfigureLinker::ID = 0;
+
+} // namespace
+} // namespace snippy
+} // namespace llvm
+
+using llvm::callDefaultCtor;
+using llvm::PassInfo;
+using llvm::PassRegistry;
+using llvm::snippy::ConfigureLinker;
+
+INITIALIZE_PASS(ConfigureLinker, DEBUG_TYPE, PASS_DESC, false, false)
+
+namespace llvm {
+
+MachineFunctionPass *createLinkerConfigurePass() {
+  return new snippy::ConfigureLinker;
+}
+
+namespace snippy {
+
+bool ConfigureLinker::runOnMachineFunction(MachineFunction &MF) {
+  auto &SGCtx = getAnalysis<GeneratorContextWrapper>().getContext();
+  if (!SGCtx.getConfig().PassCfg.CodeLayout)
+    return false;
+  auto &ProgCtx = SGCtx.getProgramContext();
+  auto &Linker = ProgCtx.getLinker();
+  const auto &FG = getAnalysis<FunctionGenerator>();
+  if (!FG.isEntryFunction(MF))
+    return false;
+
+  // Setup Start PC:
+  assert(MF.getSection());
+  Linker.setStartPC(
+      Linker.sections().getAddressFor(MF.getFunction().getSection()));
+
+  return false;
+}
+
+} // namespace snippy
+} // namespace llvm

--- a/llvm/tools/llvm-snippy/lib/FillExternalFunctionsStubsPass.cpp
+++ b/llvm/tools/llvm-snippy/lib/FillExternalFunctionsStubsPass.cpp
@@ -82,8 +82,9 @@ bool FillExternalFunctionsStubs::runOnModule(Module &M) {
             [&F](StringRef FuncName) { return F.getName() == FuncName; }))
       continue;
 
-    auto &MF =
-        State.createMachineFunctionFor(F, SnippyModule::fromModule(M).getMMI());
+    auto &MF = State.createMachineFunctionFor(
+        F, SnippyModule::fromModule(M).getMMI(),
+        SGCtx.getConfig().PassCfg.CodeLayout.has_value());
     auto *MBB = createMachineBasicBlock(MF);
     MF.push_back(MBB);
     InstructionGenerationContext IGC{*MBB, MBB->end(), SGCtx};

--- a/llvm/tools/llvm-snippy/lib/FlowGenerator.cpp
+++ b/llvm/tools/llvm-snippy/lib/FlowGenerator.cpp
@@ -106,6 +106,11 @@ static snippy::opt<bool> DisableLinkerRelaxations(
     cl::desc("Disable linker relaxations for the final image"),
     cl::cat(Options), cl::init(false), cl::Hidden);
 
+snippy::opt<bool>
+    DumpCodeAddrMapping("dump-bb-addresses",
+                        cl::desc("Dump selected basic block addresses"),
+                        cl::cat(Options), cl::init(false), cl::Hidden);
+
 } // namespace snippy
 
 namespace snippy {
@@ -213,6 +218,20 @@ static void dumpVerificationIntervalsIfNeeeded(SnippyModule &SM,
                   std::move(E));
 }
 
+static void dumpCodeAddrMapping(const Linker &Linker, raw_ostream &OS) {
+  OS << "Basic Block Addresses:\n";
+  auto &Sections = Linker.sections();
+  for (auto &E : Sections) {
+    auto BBSections = llvm::make_filter_range(E.InputSections,
+                                              [](auto &I) { return I.Addr; });
+    for (auto &[Name, Addr] : BBSections) {
+      assert(Addr);
+      OS.indent(2);
+      OS << Name << ": 0x" << llvm::utohexstr(Addr->Address) << "\n";
+    }
+  }
+}
+
 GeneratorResult FlowGenerator::generate(LLVMState &State,
                                         const DebugOptions &DebugCfg) {
 
@@ -246,9 +265,15 @@ GeneratorResult FlowGenerator::generate(LLVMState &State,
         PM.add(createLoopCanonicalizationPass());
         PM.add(createLoopLatcherPass());
 
+        if (GenCtx.getConfig().PassCfg.CodeLayout) {
+          PM.add(createCLBasicBlockPreprocessPass());
+        }
         PM.add(createRegsInitInsertionPass(
             PassCfg.RegistersConfig.InitializeRegs));
         SnippyTgt.addTargetSpecificPasses(PM);
+        if (GenCtx.getConfig().PassCfg.CodeLayout) {
+          PM.add(createCLBasicBlockPreprocessPass());
+        }
         // Pre backtrack end
 
         PM.add(createBlockGenPlanWrapperPass());
@@ -267,7 +292,9 @@ GeneratorResult FlowGenerator::generate(LLVMState &State,
 
         if (DebugCfg.DumpMI.value())
           PM.add(createPrintMachineInstrsPass(outs()));
-        PM.add(createBranchRelaxatorPass());
+
+        if (!GenCtx.getConfig().PassCfg.CodeLayout)
+          PM.add(createBranchRelaxatorPass());
         if (VerifyConsecutiveLoops)
           PM.add(createConsecutiveLoopsVerifierPass());
 
@@ -275,8 +302,17 @@ GeneratorResult FlowGenerator::generate(LLVMState &State,
         PM.add(createTrackLivenessPass());
 
         PM.add(createPostGenVerifierPass());
+        if (GenCtx.getConfig().PassCfg.CodeLayout) {
+          PM.add(createCLBasicBlockPreprocessPass());
+          PM.add(createFallThroughEraserPass());
+          PM.add(createBranchLengthenerPass());
+          PM.add(createJumpLengthenerPass());
+          PM.add(createCodeAddrSamplingPass());
+          PM.add(createLongJumpRelaxatorPass());
+        }
         PM.add(createInstructionsPostProcessPass());
-        PM.add(createFunctionDistributePass());
+        if (!GenCtx.getConfig().PassCfg.CodeLayout)
+          PM.add(createFunctionDistributePass());
 
         if (PassCfg.InstrsGenerationConfig.RunMachineInstrVerifier)
           PM.add(createMachineVerifierPass("Machine Verifier Pass report"));
@@ -289,12 +325,23 @@ GeneratorResult FlowGenerator::generate(LLVMState &State,
         PM.add(createMemAccessDumperPass());
       },
       [](PassManagerWrapper &PM) {
+        PM.add(createLinkerConfigurePass());
         PM.add(createSimulatorContextPreserverPass());
       });
 
   if (DumpMIR.isSpecified())
     writeMIRFile(MIR);
   std::vector<const SnippyModule *> Modules{&MainModule};
+  if (DumpCodeAddrMapping) {
+    if (!GenCtx.getConfig().PassCfg.CodeLayout) {
+      snippy::warn(
+          WarningName::InconsistentOptions, State.getCtx(),
+          "Option \"" + Twine() +
+              "\" was specified but code layout config was not provided",
+          "mapping won't be dumped");
+    }
+    dumpCodeAddrMapping(ProgContext.getLinker(), outs());
+  }
   bool NoRelax = DisableLinkerRelaxations;
   auto EResult = ProgContext.generateELF(Modules, ObjectType, NoRelax);
   if (!EResult)

--- a/llvm/tools/llvm-snippy/lib/Generator/CLBasicBlockPreprocessPass.cpp
+++ b/llvm/tools/llvm-snippy/lib/Generator/CLBasicBlockPreprocessPass.cpp
@@ -1,0 +1,66 @@
+//===-- CLBasicBlockPreprocessPass.cpp --------------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "../InitializePasses.h"
+
+#include "snippy/CreatePasses.h"
+
+#include "llvm/CodeGen/MachineFunctionPass.h"
+#include "llvm/Pass.h"
+
+#define DEBUG_TYPE "snippy-cl-bb-preprocess"
+#define PASS_DESC "Snippy CL basic block preprocess"
+
+namespace llvm {
+
+namespace snippy {
+
+namespace {
+
+class CLBasicBlockPreprocess : public MachineFunctionPass {
+public:
+  static char ID;
+  CLBasicBlockPreprocess() : MachineFunctionPass(ID) {};
+  void getAnalysisUsage(AnalysisUsage &AU) const override {
+    AU.setPreservesCFG();
+    MachineFunctionPass::getAnalysisUsage(AU);
+  }
+  StringRef getPassName() const override { return PASS_DESC " Pass"; }
+
+  bool runOnMachineFunction(MachineFunction &MF) override {
+    for (auto &MBB : MF) {
+      // This need to be done before first ever getSymbol()
+      // is called for MBB, because symbol is lazily created
+      // and then cached.
+      // Currently flow generator pass may cause this method
+      // to be called, so this pass should be run before it.
+      MBB.setIsBeginSection();
+      MBB.setLabelMustBeEmitted();
+    }
+    return true;
+  }
+};
+
+char CLBasicBlockPreprocess::ID = 0;
+
+} // namespace
+
+} // namespace snippy
+
+MachineFunctionPass *createCLBasicBlockPreprocessPass() {
+  return new snippy::CLBasicBlockPreprocess;
+}
+
+} // namespace llvm
+
+using llvm::callDefaultCtor;
+using llvm::PassInfo;
+using llvm::PassRegistry;
+using llvm::snippy::CLBasicBlockPreprocess;
+
+INITIALIZE_PASS(CLBasicBlockPreprocess, DEBUG_TYPE, PASS_DESC, false, false)

--- a/llvm/tools/llvm-snippy/lib/Generator/CMakeLists.txt
+++ b/llvm/tools/llvm-snippy/lib/Generator/CMakeLists.txt
@@ -3,6 +3,10 @@ set(LLVMSnippyGeneratorSources
   CallGraphState.cpp
   CFPermutation.cpp
   CFPermutationPass.cpp
+  CLBasicBlockPreprocessPass.cpp
+  CodeAddrSampler.cpp
+  CodeAddrSamplingPass.cpp
+  FallThroughsEraserPass.cpp
   FunctionGeneratorPass.cpp
   FPRNaNIdentifier.cpp
   GeneratorContext.cpp
@@ -12,8 +16,10 @@ set(LLVMSnippyGeneratorSources
   Generation.cpp
   InstructionGeneratorPass.cpp
   Interpreter.cpp
+  JumpLengthenerPass.cpp
   Linker.cpp
   IntervalsToVerify.cpp
+  LongJumpRelaxatorPass.cpp
   Policy.cpp
   RegisterGenerator.cpp
   RootRegPoolWrapperPass.cpp

--- a/llvm/tools/llvm-snippy/lib/Generator/CodeAddrSampler.cpp
+++ b/llvm/tools/llvm-snippy/lib/Generator/CodeAddrSampler.cpp
@@ -1,0 +1,79 @@
+//===-- CodeAddrSampler.cpp -------------------------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "snippy/Generator/CodeAddrSampler.h"
+#include "snippy/Support/YAMLUtils.h"
+#include "llvm/Support/YAMLTraits.h"
+
+namespace llvm {
+namespace snippy {
+
+AddressInfo CodeAddrSampler::randomAddress(const AddressGenInfo &Params) {
+  auto Access =
+      sample(AddressGenInfo::singleAccess(Params.AccessSize, Params.Alignment,
+                                          Params.AllowMisalign, /*Burst=*/false)
+
+      );
+  if (!Access)
+    snippy::fatal("Code layout schemes cannot fit Basic Block",
+                  Twine(toString(Access.takeError()))
+                      .concat(" ")
+                      .concat("Try larger code layout address ranges"));
+  auto &AI = *Access;
+  AI.MaxOffset = AI.MinOffset = 0;
+  reserve(MemRange(AI));
+  return AI;
+}
+
+template <typename SectIt>
+MemoryBank createSectionsMB(SectIt Start, SectIt Finish) {
+  MemoryBank SecMB;
+  for (auto &S : llvm::make_range(Start, Finish))
+    SecMB.addRange(MemRange{S.VMA, S.VMA + S.Size});
+  return SecMB;
+}
+
+CodeAddrSampler::CodeAddrSampler(
+    const CodeLayoutConfig &Config, const SectionsDescriptions &Sections,
+    Align Alignment)
+    : RandomMemoryAccessSampler([&]() {
+        auto RXSections = llvm::make_filter_range(
+            Sections, [](auto &S) { return S.M.R() && S.M.X(); });
+        auto SecMB = createSectionsMB(RXSections.begin(), RXSections.end());
+        auto IsContainedInSections = [&SecMB](auto &Acc) {
+          auto AddrMB = Acc.getPossibleAddresses();
+          return AddrMB.containedIn(SecMB);
+        };
+        auto ContainedAccesses =
+            llvm::make_filter_range(Config.Ranges, IsContainedInSections);
+        auto NotContainedAccesses = llvm::make_filter_range(
+            Config.Ranges, std::not_fn(IsContainedInSections));
+
+        for (auto &R : NotContainedAccesses) {
+          std::string SchemeDump;
+          raw_string_ostream SS{SchemeDump};
+          MemoryScheme MAcc;
+          MAcc.BaseAccesses.emplace_back(R.copy());
+          outputYAMLToStream(MAcc, SS);
+          LLVMContext Ctx;
+          snippy::warn(
+              WarningName::MemoryAccess, Ctx, "Possibly wrong code layout",
+              "Following scheme permits code generation outside of all "
+              "RX sections (It will be ignored)\n" +
+                  Twine(SchemeDump));
+        }
+
+        return RandomMemoryAccessSampler(RXSections.begin(), RXSections.end(),
+                                         ContainedAccesses.begin(),
+                                         ContainedAccesses.end(),
+                                         Alignment);
+      }()) {
+}
+
+} // namespace snippy
+} // namespace llvm

--- a/llvm/tools/llvm-snippy/lib/Generator/CodeAddrSamplingPass.cpp
+++ b/llvm/tools/llvm-snippy/lib/Generator/CodeAddrSamplingPass.cpp
@@ -1,0 +1,90 @@
+//===-- CodeAddrSamplingPass.cpp --------------------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "../InitializePasses.h"
+
+#include "snippy/Generator/CodeAddrSampler.h"
+#include "snippy/Generator/CodeAddrSamplingPass.h"
+#include "snippy/Generator/GenerationUtils.h"
+#include "snippy/Generator/GeneratorContextPass.h"
+
+#define DEBUG_TYPE "snippy-code-addr-sampler"
+#define PASS_DESC "Snippy Code Address Sampling"
+
+using llvm::callDefaultCtor;
+using llvm::PassInfo;
+using llvm::PassRegistry;
+using llvm::snippy::CodeAddrSampling;
+
+char CodeAddrSampling::ID = 0;
+
+INITIALIZE_PASS_BEGIN(CodeAddrSampling, DEBUG_TYPE, PASS_DESC, false, true)
+INITIALIZE_PASS_DEPENDENCY(GeneratorContextWrapper)
+INITIALIZE_PASS_END(CodeAddrSampling, DEBUG_TYPE, PASS_DESC, false, true)
+
+namespace llvm {
+
+MachineFunctionPass *createCodeAddrSamplingPass() {
+  return new snippy::CodeAddrSampling;
+}
+
+namespace snippy {
+
+void CodeAddrSampling::getAnalysisUsage(AnalysisUsage &AU) const {
+  AU.setPreservesAll();
+  AU.addRequired<GeneratorContextWrapper>();
+  MachineFunctionPass::getAnalysisUsage(AU);
+}
+
+bool CodeAddrSampling::runOnMachineFunction(MachineFunction &MF) {
+  auto &GC = getAnalysis<GeneratorContextWrapper>().getContext();
+  const auto &Cfg = GC.getConfig().PassCfg;
+  assert(Cfg.CodeLayout);
+  auto &ProgCtx = GC.getProgramContext();
+  auto &SM = SnippyModule::fromModule(*MF.getFunction().getParent());
+  const auto &Tgt = ProgCtx.getLLVMState().getSnippyTarget();
+  auto &Sampler = ProgCtx.getOrCreateAddrSampler(Cfg);
+  auto &Linker = ProgCtx.getLinker();
+  auto SampleAddrForBB = [&](auto &MBB, StringRef GVName,
+                             StringRef InputSectionName) {
+    auto &State = ProgCtx.getLLVMState();
+    auto BlockSize = State.getCodeBlockSize(MBB.begin(), MBB.end());
+    auto &STI = MBB.getParent()->getSubtarget();
+    AddressGenInfo Params{BlockSize, Tgt.getCodeAlignment(STI),
+                          /* AllowMisalign */ false,
+                          /* Burst */ false};
+    auto AI = Sampler.randomAddress(Params);
+    Linker.sections().addInputSection(InputSectionName, AI);
+    auto &TM = State.getTargetMachine();
+    auto AddrLen = Tgt.getAddrRegLen(TM);
+    auto &InstrGenCfg = Cfg.InstrsGenerationConfig;
+    if (!InstrGenCfg.NeedsRelocations
+    )
+      return;
+    auto &GP = ProgCtx.getOrAddGlobalsPoolFor(
+        SM, "Failed to allocate space for relocation for BB "
+            "address (code addr sampler)");
+    auto *GV = GP.getGV(GVName);
+    if (!GV)
+      GV = GP.createGV(
+          APInt(AddrLen, 3), /*Alignment*/ 1, GlobalValue::InternalLinkage,
+          GVName, /*Reason*/ "Relocation for BB address", /* IsConst */ true);
+    auto *Type = IntegerType::get(State.getCtx(), AddrLen);
+    auto *AddrConstant = ConstantInt::get(Type, AI.Address);
+    GV->setInitializer(AddrConstant);
+  };
+
+  StringRef FirstBlockName = MF.getFunction().getSection();
+  SampleAddrForBB(MF.front(), FirstBlockName, FirstBlockName);
+  for (auto &MBB : llvm::drop_begin(MF))
+    SampleAddrForBB(MBB, getMBBSectionName(MBB), getMBBSectionName(MBB));
+  return false;
+}
+
+} // namespace snippy
+} // namespace llvm

--- a/llvm/tools/llvm-snippy/lib/Generator/FallThroughsEraserPass.cpp
+++ b/llvm/tools/llvm-snippy/lib/Generator/FallThroughsEraserPass.cpp
@@ -1,0 +1,43 @@
+//===-- FallThroughEraserPass.cpp -------------------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "snippy/Generator/FallThroughsEraserPass.h"
+#include "snippy/Generator/GenerationUtils.h"
+#include "snippy/Generator/GeneratorContextPass.h"
+
+namespace llvm {
+
+MachineFunctionPass *createFallThroughEraserPass() {
+  return new snippy::FallThroughEraserPass;
+}
+
+namespace snippy {
+char FallThroughEraserPass::ID = 0;
+
+void FallThroughEraserPass::getAnalysisUsage(AnalysisUsage &AU) const {
+  AU.setPreservesCFG();
+  AU.addRequired<GeneratorContextWrapper>();
+  MachineFunctionPass::getAnalysisUsage(AU);
+}
+
+bool FallThroughEraserPass::runOnMachineFunction(MachineFunction &MF) {
+  auto &GC = getAnalysis<GeneratorContextWrapper>().getContext();
+  auto &ProgCtx = GC.getProgramContext();
+  auto &Tgt = ProgCtx.getLLVMState().getSnippyTarget();
+  bool Changed = false;
+  for (auto &MBB : MF) {
+    auto *FallThrough = MBB.getFallThrough(/* JumpToFallThrough */ false);
+    if (!FallThrough)
+      continue;
+    Tgt.generateJump(MBB, MBB.end(), *FallThrough, ProgCtx.getLLVMState());
+    Changed = true;
+  }
+  return Changed;
+}
+} // namespace snippy
+} // namespace llvm

--- a/llvm/tools/llvm-snippy/lib/Generator/FunctionGeneratorPass.cpp
+++ b/llvm/tools/llvm-snippy/lib/Generator/FunctionGeneratorPass.cpp
@@ -204,7 +204,8 @@ MachineFunction &FunctionGenerator::createFunction(
           : (Twine(SectionName) + "." + Name).str();
   auto &MF = State.createMachineFunctionFor(
       State.createFunction(M, FinalName, SectionName, Linkage),
-      SnippyModule::fromModule(M).getMMI());
+      SnippyModule::fromModule(M).getMMI(),
+      SGCtx.getConfig().PassCfg.CodeLayout.has_value());
   auto *MBB = createMachineBasicBlock(MF);
   assert(MBB);
   MF.push_back(MBB);
@@ -345,15 +346,17 @@ void FunctionGenerator::initExecutionPath() {
   auto &L = SGCtx.getProgramContext().getLinker();
   assert(L.sections().hasOutputSectionFor(Linker::kDefaultTextSectionName));
   auto &PassCfg = Cfg.PassCfg;
+  auto CodeLayout = PassCfg.CodeLayout.has_value();
   auto DefaultCodeSection =
       L.sections().getOutputSectionFor(Linker::kDefaultTextSectionName);
-  if (PassCfg.InstrsGenerationConfig.ChainedRXSectionsFill)
+  if (PassCfg.InstrsGenerationConfig.ChainedRXSectionsFill || CodeLayout)
     for (auto &RXSection : llvm::make_filter_range(L.sections(), [](auto &S) {
            return S.OutputSection.Desc.M.X();
          })) {
       if (!L.sections().hasOutputSectionFor(RXSection.OutputSection.Name))
-        L.sections().addInputSectionFor(RXSection.OutputSection.Desc,
-                                        RXSection.OutputSection.Name);
+        if (!CodeLayout)
+          L.sections().addInputSectionFor(RXSection.OutputSection.Desc,
+                                          RXSection.OutputSection.Name);
       ExecutionPath.push_back(RXSection);
     }
 
@@ -366,7 +369,7 @@ void FunctionGenerator::initExecutionPath() {
                 });
     } else
       RandEngine::shuffle(ExecutionPath.begin(), ExecutionPath.end());
-  } else {
+  } else if (!CodeLayout) {
     checkForUnusedRXSections(L.sections(), DefaultCodeSection, State.getCtx());
     ExecutionPath.push_back(Linker::SectionEntry{
         DefaultCodeSection, {{std::string(Linker::kDefaultTextSectionName)}}});

--- a/llvm/tools/llvm-snippy/lib/Generator/JumpLengthenerPass.cpp
+++ b/llvm/tools/llvm-snippy/lib/Generator/JumpLengthenerPass.cpp
@@ -1,0 +1,112 @@
+//===-- JumpLengthenerPass.cpp ----------------------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "snippy/Generator/JumpLengthenerPass.h"
+#include "snippy/CreatePasses.h"
+#include "snippy/Generator/GenerationUtils.h"
+#include "snippy/Generator/GeneratorContextPass.h"
+#include "snippy/Generator/Policy.h"
+
+#include "../InitializePasses.h"
+
+#define DEBUG_TYPE "snippy-jump-lengthener"
+#define PASS_DESC "Snippy Jump Lengthener"
+
+namespace llvm {
+namespace snippy {
+char JumpLengthener::ID = 0;
+} // namespace snippy
+
+snippy::ActiveImmutablePassInterface *createJumpLengthenerPass() {
+  return new snippy::JumpLengthener;
+}
+
+} // namespace llvm
+
+using llvm::callDefaultCtor;
+using llvm::PassInfo;
+using llvm::PassRegistry;
+using llvm::snippy::JumpLengthener;
+
+SNIPPY_INITIALIZE_PASS(JumpLengthener, DEBUG_TYPE, PASS_DESC, false)
+
+namespace llvm {
+namespace snippy {
+
+static void lengthenJump(MachineInstr &J, InstructionGenerationContext &IGC,
+                         const SnippyTarget &Tgt, IndJumpInfoMap &JumpMap) {
+  auto *MBBPtr = J.getParent();
+  assert(MBBPtr);
+  auto &MBB = *MBBPtr;
+  auto *TBB = Tgt.getBranchDestination(J);
+  assert(TBB);
+  auto &ProgCtx = IGC.ProgCtx;
+
+  auto &GP = ProgCtx.getOrAddGlobalsPoolFor(
+      IGC.getSnippyModule(), "Failed to allocate space for relocation for BB "
+                             "address (jump lengthener)");
+  auto *GV = getGVForMBB(*TBB, GP, ProgCtx);
+  auto Addr = GP.getGVAddress(GV);
+  auto FirstTerm = MBB.getFirstInstrTerminator();
+  // Point right before first terminator
+  auto Prev = std::make_reverse_iterator(FirstTerm);
+  IGC.Ins = std::next(J.getIterator());
+
+  auto NewJump = Tgt.insertJumpThroughRelocation(IGC, Addr);
+  NewJump->cloneInstrSymbols(*MBB.getParent(), J);
+  // Instruction right after Prev instr
+  auto FirstInserted = Prev.base();
+  auto InstrPtrs = llvm::map_range(llvm::make_range(FirstInserted, FirstTerm),
+                                   [](auto &MI) { return &MI; });
+
+  JumpMap.addJump(*NewJump,
+                  IndJumpInfo{TBB, {InstrPtrs.begin(), InstrPtrs.end()}});
+}
+
+StringRef JumpLengthener::getPassName() const { return PASS_DESC " Pass"; }
+
+void JumpLengthener::getAnalysisUsage(AnalysisUsage &AU) const {
+  AU.setPreservesCFG();
+  AU.addRequired<GeneratorContextWrapper>();
+  MachineFunctionPass::getAnalysisUsage(AU);
+}
+
+bool JumpLengthener::runOnMachineBasicBlock(MachineBasicBlock &MBB,
+                                            IndJumpInfoMap &JumpMap) {
+  auto &GC = getAnalysis<GeneratorContextWrapper>().getContext();
+  auto &ProgCtx = GC.getProgramContext();
+  auto &Tgt = ProgCtx.getLLVMState().getSnippyTarget();
+  auto FirstTermIt = MBB.getFirstTerminator();
+  if (FirstTermIt == MBB.end())
+    return false;
+
+  auto Jumps = llvm::make_filter_range(
+      MBB.terminators(), [](auto &MI) { return MI.isUnconditionalBranch(); });
+  InstructionGenerationContext IGC{MBB, MBB.getFirstTerminator(), GC};
+  auto RP = IGC.pushRegPool();
+
+  for (auto &J : llvm::make_early_inc_range(Jumps)) {
+    lengthenJump(J, IGC, Tgt, JumpMap);
+    J.eraseFromParent();
+  }
+  return true;
+}
+
+bool JumpLengthener::runOnMachineFunction(MachineFunction &MF) {
+  auto &GC = getAnalysis<GeneratorContextWrapper>().getContext();
+  if (!GC.getConfig().PassCfg.InstrsGenerationConfig.NeedsRelocations)
+    return false;
+  bool Changed = false;
+  auto &JumpMap = get<IndJumpInfoMap>(MF);
+  for (auto &MBB : MF)
+    Changed |= runOnMachineBasicBlock(MBB, JumpMap);
+  return Changed;
+}
+
+} // namespace snippy
+} // namespace llvm

--- a/llvm/tools/llvm-snippy/lib/Generator/Linker.cpp
+++ b/llvm/tools/llvm-snippy/lib/Generator/Linker.cpp
@@ -225,6 +225,29 @@ bool Linker::LinkedSections::hasOutputSectionFor(StringRef SectionName) const {
   });
 }
 
+static bool operator<(const Linker::InputSection &LHS,
+                      const Linker::InputSection &RHS) {
+  auto LHSAddr = transformOpt(LHS.Addr, &AddressInfo::Address);
+  auto RHSAddr = transformOpt(RHS.Addr, &AddressInfo::Address);
+  return LHSAddr < RHSAddr;
+}
+
+void Linker::LinkedSections::addInputSection(StringRef Name, AddressInfo AI) {
+  MemRange InSectionRange(AI);
+  auto OutSection = std::find_if(begin(), end(), [InSectionRange](auto &Entry) {
+    auto &Desc = Entry.OutputSection.Desc;
+    MemRange OutSect(Desc.VMA, Desc.VMA + Desc.Size);
+    return OutSect.intersect(InSectionRange) == InSectionRange;
+  });
+  assert(OutSection != end());
+  auto &InputSections = OutSection->InputSections;
+  InputSections.push_back({Name.str(), AI});
+  [[maybe_unused]] auto [It, Inserted] =
+      SectToAddrMap.try_emplace(Name.str(), AI.Address);
+  assert(Inserted && "Attempt to overwrite InputSection address");
+  llvm::sort(InputSections);
+}
+
 const Linker::NamedOutputSection &
 Linker::LinkedSections::getOutputSectionFor(StringRef SectionName) const {
   auto S = std::find_if(begin(), end(), [SectionName](auto &Section) {
@@ -234,6 +257,13 @@ Linker::LinkedSections::getOutputSectionFor(StringRef SectionName) const {
   });
   assert(S != end());
   return S->OutputSection;
+}
+
+MemAddr Linker::LinkedSections::getAddressFor(StringRef SectionName) const {
+  auto Found = SectToAddrMap.find(SectionName.str());
+  assert(Found != SectToAddrMap.end());
+  auto &Addr = Found->second;
+  return Addr;
 }
 
 std::string
@@ -250,6 +280,7 @@ void Linker::LinkedSections::addInputSectionFor(const SectionDesc &Desc,
   assert(SectIt != end() &&
          "Can't find current section in the output sections");
   SectIt->InputSections.push_back({InSectName.str()});
+  llvm::sort(SectIt->InputSections);
 }
 
 std::string Linker::getMangledName(StringRef SectionName) const {
@@ -356,7 +387,16 @@ Expected<std::string> Linker::createLinkerScriptImpl(bool Shared) const {
       STS << "  . +=" << utostr(SE.OutputSection.Desc.Size) << ";\n";
       STS << "  PROVIDE(" << OutSectionName << "_end_ = .);\n";
     } else {
+      auto HasAddressedSections = llvm::any_of(
+          SE.InputSections, [&](auto &IS) { return IS.Addr.has_value(); });
       for (auto &&InputSection : SE.InputSections) {
+        if (HasAddressedSections) {
+          // We should not output input sections with no address here since
+          // all the code should be in addressed sections.
+          if (!InputSection.Addr)
+            continue;
+          STS << "  . = " << utostr(InputSection.Addr->Address) << ";\n";
+        }
         STS << "  KEEP(*(" << InputSection.Name << "))\n";
       }
     }
@@ -422,7 +462,16 @@ std::string Linker::createLinkerScriptImplLegacy(bool Export) const {
         STS << "  . +=" << utostr(SE.OutputSection.Desc.Size) << ";\n";
         STS << "  PROVIDE(" << OutSectionName << "_end_ = .);\n";
       } else {
+        auto HasAddressedSections = llvm::any_of(
+            SE.InputSections, [&](auto &IS) { return IS.Addr.has_value(); });
         for (auto &&InputSection : SE.InputSections) {
+          if (HasAddressedSections) {
+            // We should not output input sections with no address here since
+            // all the code should be in addressed sections.
+            if (!InputSection.Addr)
+              continue;
+            STS << "  . = " << utostr(InputSection.Addr->Address) << ";\n";
+          }
           STS << "  KEEP(*(" << InputSection.Name << "))\n";
         }
       }

--- a/llvm/tools/llvm-snippy/lib/Generator/LongJumpRelaxatorPass.cpp
+++ b/llvm/tools/llvm-snippy/lib/Generator/LongJumpRelaxatorPass.cpp
@@ -1,0 +1,157 @@
+//===-- LongJumpRelaxatorPass.cpp -------------------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "../InitializePasses.h"
+
+#include "snippy/Generator/CodeAddrSamplingPass.h"
+#include "snippy/Generator/GenerationUtils.h"
+#include "snippy/Generator/GeneratorContextPass.h"
+#include "snippy/Generator/JumpLengthenerPass.h"
+
+#include "llvm/CodeGen/MachineFunctionPass.h"
+
+#define DEBUG_TYPE "snippy-long-jump-relaxator"
+#define PASS_DESC "Snippy Long Jump Relaxator"
+
+namespace llvm {
+namespace snippy {
+
+static void eraseJumpAndAssociates(MachineInstr &J, IndJumpInfoMap &JumpMap) {
+  auto &[TBB, SupportInstrs] = JumpMap.getInfo(J);
+  for (auto *I : SupportInstrs) {
+    assert(I);
+    I->eraseFromParent();
+  }
+  J.eraseFromParent();
+  JumpMap.remove(J);
+}
+
+static MachineInstr &
+replaceWithJump(MachineBasicBlock &MBB, MachineBasicBlock &TBB,
+                const IndJumpInfo &Info, MachineBasicBlock::iterator J,
+                GeneratorContext &GC, const SnippyTarget &Tgt,
+                IndJumpInfoMap &JumpMap) {
+  auto NewJumpIt =
+      Tgt.generateJump(MBB, J, TBB, GC.getProgramContext().getLLVMState());
+  auto *MF = MBB.getParent();
+  assert(MF);
+  NewJumpIt->cloneInstrSymbols(*MF, *J);
+  eraseJumpAndAssociates(*J, JumpMap);
+  return *NewJumpIt;
+}
+
+static void replaceWithBranch(MachineBasicBlock &MBB, const IndJumpInfo &Info,
+                              MachineBasicBlock::iterator J,
+                              GeneratorContext &GC, const SnippyTarget &Tgt,
+                              IndJumpInfoMap &JumpMap) {
+  auto Reversed = llvm::reverse(llvm::make_range(MBB.getFirstTerminator(), J));
+  auto BrIt = llvm::find_if(
+      Reversed, [](const auto &MI) { return MI.isConditionalBranch(); });
+  auto &[TBB, SupportInstrs] = Info;
+  assert(TBB);
+
+  // Simply replace single indirect jump with jump
+  if (BrIt == Reversed.end()) {
+    replaceWithJump(MBB, *TBB, Info, J, GC, Tgt, JumpMap);
+    return;
+  }
+  auto &Br = *BrIt;
+  assert(Br.isConditionalBranch());
+  bool IsFallback = std::next(BrIt.base()) == J;
+  // Simply replace fallback jump
+  if (!IsFallback) {
+    replaceWithJump(MBB, *TBB, Info, J, GC, Tgt, JumpMap);
+    return;
+  }
+  // Replace target jump and make it Br's destination
+  auto &NewJump = replaceWithJump(MBB, *TBB, Info, J, GC, Tgt, JumpMap);
+  assert(NewJump.getPreInstrSymbol());
+  Tgt.replaceBranchDest(Br, NewJump);
+  return;
+}
+
+namespace {
+class LongJumpRelaxator final : public MachineFunctionPass {
+  bool runOnMachineBasicBlock(MachineBasicBlock &MBB,
+                              IndJumpInfoMap &JumpMap) const;
+
+public:
+  static char ID;
+
+  LongJumpRelaxator() : MachineFunctionPass(ID) {}
+
+  StringRef getPassName() const override;
+
+  void getAnalysisUsage(AnalysisUsage &AU) const override;
+
+  bool runOnMachineFunction(MachineFunction &MF) override;
+};
+} // namespace
+char LongJumpRelaxator::ID;
+
+StringRef LongJumpRelaxator::getPassName() const { return PASS_DESC " Pass"; }
+} // namespace snippy
+} // namespace llvm
+
+using llvm::callDefaultCtor;
+using llvm::PassInfo;
+using llvm::PassRegistry;
+using llvm::snippy::LongJumpRelaxator;
+
+INITIALIZE_PASS_BEGIN(LongJumpRelaxator, DEBUG_TYPE, PASS_DESC, false, false)
+INITIALIZE_PASS_DEPENDENCY(GeneratorContextWrapper)
+INITIALIZE_PASS_END(LongJumpRelaxator, DEBUG_TYPE, PASS_DESC, false, false)
+
+namespace llvm {
+
+MachineFunctionPass *createLongJumpRelaxatorPass() {
+  return new snippy::LongJumpRelaxator;
+}
+
+namespace snippy {
+
+void LongJumpRelaxator::getAnalysisUsage(AnalysisUsage &AU) const {
+  AU.setPreservesCFG();
+  AU.addRequired<GeneratorContextWrapper>();
+  AU.addRequired<JumpLengthener>();
+  MachineFunctionPass::getAnalysisUsage(AU);
+}
+
+bool LongJumpRelaxator::runOnMachineBasicBlock(MachineBasicBlock &MBB,
+                                               IndJumpInfoMap &JumpMap) const {
+  auto Jumps = llvm::make_filter_range(
+      MBB.terminators(), [](auto &MI) { return MI.isIndirectBranch(); });
+  auto &GC = getAnalysis<GeneratorContextWrapper>().getContext();
+  auto &ProgCtx = GC.getProgramContext();
+  auto &Tgt = ProgCtx.getLLVMState().getSnippyTarget();
+  auto &Linker = ProgCtx.getLinker();
+  auto CurrentLoc = Linker.sections().getAddressFor(getMBBSectionName(MBB));
+  bool Changed = false;
+  for (auto &J : llvm::make_early_inc_range(Jumps)) {
+    auto &Info = JumpMap.getInfo(J);
+    assert(Info.MBB);
+    auto TBBLoc = Linker.sections().getAddressFor(getMBBSectionName(*Info.MBB));
+    auto Distance = std::max(TBBLoc, CurrentLoc) - std::min(TBBLoc, CurrentLoc);
+    if (Tgt.fitsCondBranch(Distance)) {
+      replaceWithBranch(MBB, Info, J, GC, Tgt, JumpMap);
+      Changed = true;
+    }
+  }
+  return Changed;
+}
+
+bool LongJumpRelaxator::runOnMachineFunction(MachineFunction &MF) {
+  bool Changed = false;
+  auto &JumpMap = getAnalysis<JumpLengthener>().get<IndJumpInfoMap>(MF);
+  for (auto &MBB : llvm::drop_begin(MF))
+    Changed |= runOnMachineBasicBlock(MBB, JumpMap);
+  return Changed;
+}
+
+} // namespace snippy
+} // namespace llvm

--- a/llvm/tools/llvm-snippy/lib/Generator/SnippyModule.cpp
+++ b/llvm/tools/llvm-snippy/lib/Generator/SnippyModule.cpp
@@ -8,6 +8,8 @@
 
 #include "snippy/Generator/SnippyModule.h"
 #include "snippy/Config/Config.h"
+#include "snippy/Generator/CodeAddrSampler.h"
+#include "snippy/Generator/CodeAddrSamplingPass.h"
 #include "snippy/Generator/Linker.h"
 #include "snippy/GeneratorUtils/LLVMState.h"
 #include "snippy/InitializePasses.h"
@@ -79,6 +81,16 @@ void SnippyModule::generateObject(const PassInserter &BeforePrinter,
 
   outs().flush(); // FIXME: this is currently needed because
                   //        MachineFunctionPrinter don't flush
+}
+
+CodeAddrSampler &
+SnippyProgramContext::getOrCreateAddrSampler(const PassConfig &Cfg) {
+  auto &TM = getLLVMState().getTargetMachine();
+  if (!PSampler)
+    PSampler = std::make_unique<CodeAddrSampler>(
+        *Cfg.CodeLayout, Cfg.ProgramCfg->Sections,
+        TM.createDataLayout().getPointerABIAlignment(/* Address Space */ 0));
+  return *PSampler;
 }
 
 void SnippyProgramContext::initializeROMSection(const ProgramConfig &Settings) {

--- a/llvm/tools/llvm-snippy/lib/GeneratorUtils/LLVMState.cpp
+++ b/llvm/tools/llvm-snippy/lib/GeneratorUtils/LLVMState.cpp
@@ -193,6 +193,7 @@ Expected<LLVMState> LLVMState::create(const SelectedTargetInfo &TargetInfo) {
       std::unique_ptr<MCCodeEmitter>(T.createMCCodeEmitter(*MCII, *MCCtx));
   auto Disassembler =
       std::unique_ptr<MCDisassembler>(T.createMCDisassembler(*STI, *MCCtx));
+  TM->Options.UniqueBasicBlockSectionNames = 1;
 
   return LLVMState(SnippyTgt, std::move(TM), std::move(MCCtx),
                    std::move(CodeEmitter), std::move(Disassembler));

--- a/llvm/tools/llvm-snippy/lib/InitializePasses.cpp
+++ b/llvm/tools/llvm-snippy/lib/InitializePasses.cpp
@@ -37,4 +37,7 @@ void llvm::snippy::initializeSnippyPasses(PassRegistry &Registry) {
   initializeBlockGenPlanningPass(Registry);
   initializeMemoryAccessDumperPass(Registry);
   initializeConsecutiveLoopsVerifierPass(Registry);
+  initializeCLBasicBlockPreprocessPass(Registry);
+  initializeConfigureLinkerPass(Registry);
+  initializeJumpLengthenerPass(Registry);
 }

--- a/llvm/tools/llvm-snippy/lib/InitializePasses.h
+++ b/llvm/tools/llvm-snippy/lib/InitializePasses.h
@@ -40,5 +40,11 @@ void initializeMemoryAccessDumperPass(llvm::PassRegistry &);
 void initializeRISCVExpandSnippyPseudoPass(PassRegistry &);
 void initializeRISCVZcmpPopretCombinePass(PassRegistry &);
 void initializeConsecutiveLoopsVerifierPass(PassRegistry &);
+void initializeCLBasicBlockPreprocessPass(PassRegistry &);
+void initializeBranchLengthenerPass(PassRegistry &);
+void initializeJumpLengthenerPass(PassRegistry &);
+void initializeCodeAddrSamplingPass(PassRegistry &);
+void initializeLongJumpRelaxatorPass(PassRegistry &);
+void initializeConfigureLinkerPass(PassRegistry &);
 
 } // namespace llvm

--- a/llvm/tools/llvm-snippy/lib/PrologueEpilogueInsertionPass.cpp
+++ b/llvm/tools/llvm-snippy/lib/PrologueEpilogueInsertionPass.cpp
@@ -91,6 +91,16 @@ public:
       llvm::copy(SGCtx.getConfig().ProgramCfg.getRegsSpilledToStack(),
                  std::back_inserter(Ret));
     } else {
+      // Code layout may modify function code after this pass and it's
+      // not enough to save only mutated registers if code layout enabled,
+      // so we should follow the ABI
+      if (SGCtx.getConfig().PassCfg.CodeLayout) {
+        auto &State = ProgCtx.getLLVMState();
+        auto &Tgt = State.getSnippyTarget();
+        llvm::copy(Tgt.getRegsPreservedByABI(State.getSubtargetInfo()),
+                   std::back_inserter(Ret));
+        return Ret;
+      }
       auto RegSet = getAllMutatedRegs(MF);
       llvm::copy(RegSet, std::back_inserter(Ret));
     }
@@ -372,6 +382,8 @@ bool PrologueEpilogueInsertion::insertPrologue(
   auto &SM = InstrGenCtx.getSnippyModule();
   SM.getOrAddResult<ObjectMetadata>().EntryPrologueInstrCnt =
       std::distance(MBB->begin(), Ins);
+  if (SGCtx.getConfig().PassCfg.CodeLayout)
+    return true;
   // For entry also check that function still fits assigned section
   // after prologue insertion
   auto &&[FSize, SectionInfo] = getFunctionSizeInfo(MF);
@@ -448,6 +460,8 @@ bool PrologueEpilogueInsertion::insertEpilogue(
   auto &SM = InstrGenCtx.getSnippyModule();
   SM.getOrAddResult<ObjectMetadata>().EntryEpilogueInstrCnt =
       std::distance(FirstInserted, MBB->end());
+  if (SGCtx.getConfig().PassCfg.CodeLayout)
+    return true;
   // For exit also check that function still fits assigned section
   // after epilogue insertion
   auto &&[FSize, SectionInfo] = getFunctionSizeInfo(MF);

--- a/llvm/tools/llvm-snippy/lib/RegsInitInsertionPass.cpp
+++ b/llvm/tools/llvm-snippy/lib/RegsInitInsertionPass.cpp
@@ -89,6 +89,9 @@ bool RegsInitInsertion::runOnMachineFunction(MachineFunction &MF) {
   auto *BlockRegsInit = createMachineBasicBlock(MF);
   auto *SuccessorBlockPtr = &MF.front();
   auto InsertIterPos = MF.begin();
+  if (SGCtx.getConfig().PassCfg.CodeLayout)
+    SnippyTgt.generateJump(*BlockRegsInit, BlockRegsInit->getFirstTerminator(),
+                           *SuccessorBlockPtr, State);
   BlockRegsInit->addSuccessor(SuccessorBlockPtr);
   MF.insert(InsertIterPos, BlockRegsInit);
   SFM.RegsInitBlock = BlockRegsInit;

--- a/llvm/tools/llvm-snippy/lib/Target/RISCV/Target.cpp
+++ b/llvm/tools/llvm-snippy/lib/Target/RISCV/Target.cpp
@@ -1814,6 +1814,11 @@ public:
     auto DestBBOpNum = Branch.getNumExplicitOperands() - 1;
     return Branch.getOperand(DestBBOpNum).getMBB();
   }
+  bool branchDestinationIsMBB(const MachineInstr &Branch) const {
+    assert(Branch.isBranch());
+    auto DestBBOpNum = Branch.getNumExplicitOperands() - 1;
+    return Branch.getOperand(DestBBOpNum).isMBB();
+  }
 
   bool branchNeedsVerification(const MachineInstr &Branch) const override {
     assert(Branch.isBranch());
@@ -2002,12 +2007,27 @@ public:
                           InstrInfo.get(RISCV::PseudoBR))
         .addMBB(&To);
   }
+  bool replaceBranchDest(MachineInstr &Branch,
+                         MachineBasicBlock::iterator To) const override {
+    assert(Branch.isBranch());
+    auto DestOpIdx = Branch.getNumExplicitOperands() - 1;
+    Branch.removeOperand(DestOpIdx);
+    auto *Symbol = To->getPreInstrSymbol();
+    assert(Symbol);
+    auto NewDestOperand = MachineOperand::CreateMCSymbol(Symbol);
+    Branch.addOperand(NewDestOperand);
+    return true;
+  }
 
   bool replaceBranchDest(MachineInstr &Branch,
                          MachineBasicBlock &NewDestMBB) const override {
-    auto *OldDestBB = getBranchDestination(Branch);
-    if (OldDestBB == &NewDestMBB)
-      return false;
+    auto ShouldReplaceSuccessor = branchDestinationIsMBB(Branch);
+    MachineBasicBlock *OldDestBB = nullptr;
+    if (ShouldReplaceSuccessor) {
+      OldDestBB = getBranchDestination(Branch);
+      if (OldDestBB == &NewDestMBB)
+        return false;
+    }
     assert(Branch.getNumExplicitOperands() >= 1);
     auto DestBBOpNum = Branch.getNumExplicitOperands() - 1;
     Branch.removeOperand(DestBBOpNum);
@@ -2015,6 +2035,9 @@ public:
     auto NewDestOperand = MachineOperand::CreateMBB(&NewDestMBB);
     Branch.addOperand(NewDestOperand);
 
+    if (!ShouldReplaceSuccessor)
+      return true;
+    assert(OldDestBB);
     auto *BranchBB = Branch.getParent();
     assert(BranchBB);
     if (Branch.isConditionalBranch()) {
@@ -4339,6 +4362,30 @@ private:
       return 2;
     return 4;
   }
+  MachineBasicBlock::iterator
+  insertJumpThroughRelocation(InstructionGenerationContext &IGC,
+                              uint64_t Addr) const override {
+    auto &MBB = IGC.MBB;
+    auto Ins = IGC.Ins;
+    auto &RP = IGC.getRegPool();
+    auto &ProgCtx = IGC.ProgCtx;
+    auto &State = ProgCtx.getLLVMState();
+    auto &RI = State.getRegInfo();
+    auto &InstrInfo = State.getInstrInfo();
+    auto &RegClass = RI.getRegClass(RISCV::GPRJALRRegClassID);
+    auto Reg =
+        RP.getAvailableRegister("Reg to be used by JALR in relocation", RI,
+                                RegClass, MBB, AccessMaskBit::PrimaryRW);
+    RP.addReserved(Reg);
+    IGC.Ins = MBB.getFirstTerminator();
+    loadRegFromAddr(IGC, Addr, Reg);
+    IGC.Ins = Ins;
+    return *getSupportInstBuilder(*this, MBB, Ins, State.getCtx(),
+                                  InstrInfo.get(RISCV::PseudoBRIND))
+                .addReg(Reg)
+                .addImm(0)
+                .getInstr();
+  }
 
   MachineBasicBlock::iterator generateJump(MachineBasicBlock &MBB,
                                            MachineBasicBlock::iterator Ins,
@@ -4349,6 +4396,14 @@ private:
                                   InstrInfo.get(RISCV::PseudoBR))
                 .addMBB(&TBB)
                 .getInstr();
+  }
+
+  bool fitsCondBranch(uint64_t Distance) const override {
+    return fitsBranch(Distance);
+  }
+
+  bool fitsUncondBranch(uint64_t Distance) const override {
+    return fitsJump(Distance);
   }
 
   void addAsmPrinterFlags(MachineInstr &MI) const override {
@@ -5035,7 +5090,7 @@ matchRVVOpcodesWithDisallowedIntersectingAccesses(const OpcodeHistogram &OpHist,
   if (!RVVDisallowIntersectingMemAccesses.isSpecified())
     return {};
 
-  auto &OpcRegex = *RVVDisallowIntersectingMemAccesses.getValue().Regex;
+  auto &OpcRegex = *RVVDisallowIntersectingMemAccesses.getValue().RegexPtr;
   DenseSet<unsigned> MatchedOpcodes;
   for (auto Opcode : make_filter_range(
            make_first_range(OpHist.topOpcodes()), [](unsigned Opc) {

--- a/llvm/tools/llvm-snippy/lib/Target/X86/Target.cpp
+++ b/llvm/tools/llvm-snippy/lib/Target/X86/Target.cpp
@@ -392,6 +392,10 @@ public:
                          MachineBasicBlock &NewDestMBB) const override {
     reportUnimplementedError();
   }
+  bool replaceBranchDest(MachineInstr &Branch,
+                         MachineBasicBlock::iterator To) const override {
+    reportUnimplementedError();
+  }
 
   bool replaceBranchDest(MachineBasicBlock &BranchMBB,
                          MachineBasicBlock &OldDestMBB,
@@ -691,10 +695,23 @@ public:
     reportUnimplementedError();
   }
 
+  MachineBasicBlock::iterator
+  insertJumpThroughRelocation(InstructionGenerationContext &IGC,
+                              uint64_t Addr) const override {
+    reportUnimplementedError();
+  }
+
   MachineBasicBlock::iterator generateJump(MachineBasicBlock &MBB,
                                            MachineBasicBlock::iterator Ins,
                                            MachineBasicBlock &TBB,
                                            LLVMState &State) const override {
+    reportUnimplementedError();
+  }
+  bool fitsCondBranch(uint64_t Distance) const override {
+    reportUnimplementedError();
+  }
+
+  bool fitsUncondBranch(uint64_t Distance) const override {
     reportUnimplementedError();
   }
 


### PR DESCRIPTION
[snippy] implement basic block layout scheme

This patch adds support for code-layout feature that allows to configure
addresses for basic blocks. Instead of consequently filling rx section
snippy randomly samples addresses for each basic block from specified
code-layout addresses.