### PR TITLE
[snippy] Reject function-number/function-layers with explicit call-graph

### DIFF
--- a/llvm/test/tools/llvm-snippy/call-graph-function-number-error.yaml
+++ b/llvm/test/tools/llvm-snippy/call-graph-function-number-error.yaml
@@ -1,0 +1,36 @@
+# RUN: not llvm-snippy %s |& FileCheck %s
+
+# CHECK: error: Option "function-number" cannot be used together with "call-graph"
+
+include:
+  - Inputs/sections.yaml
+
+options:
+  mtriple: riscv64
+  mattr: +m
+  function-number: 37
+  num-instrs: 100
+  dump-mf: true
+
+histogram:
+  - [ADD, 1.0]
+  - [ADDI, 1.0]
+  - [SUB, 1.0]
+  - [MUL, 1.0]
+
+call-graph:
+  entry-point: SnippyFunction
+  function-list:
+    - name: SnippyFunction
+      callees:
+        - fun1
+        - fun2
+        - fun3
+    - name: fun1
+      callees:
+        - fun2
+    - name: fun2
+      callees:
+        - fun3
+    - name: fun3
+      external: true

--- a/llvm/test/tools/llvm-snippy/calls/calls-randomize-ra-for-func.yaml
+++ b/llvm/test/tools/llvm-snippy/calls/calls-randomize-ra-for-func.yaml
@@ -1,8 +1,7 @@
 # COM: This test checks that option randomize-ra can be specified for specific
 #      functions in call-graph.
 
-# RUN: llvm-snippy %S/calls-randomize-ra.yaml %s -redefine-ra=reg::X7 \
-# RUN:   -model-plugin None &> %t.mf
+# RUN: llvm-snippy %s -redefine-ra=reg::X7 -model-plugin None &> %t.mf
 
 
 # COM: Here we check that there are exactly two different return addresses (for
@@ -35,6 +34,22 @@
 # COM: Here we check that all lines contain 'x7 = '
 # RUN: | not grep -n -v 'x7 = '
 
+
+options:
+  mtriple: riscv64
+  num-instrs: 1000
+  num-instr-ancil: 50
+  verify-mi: on
+  dump-mf: on
+
+include:
+  - Inputs/sections-with-stack.yaml
+
+histogram:
+  - [ADD, 1.0]
+  - [ADDI, 1.0]
+  - [SUB, 1.0]
+  - [JAL, 1.0]
 
 call-graph:
   entry-point: fun4

--- a/llvm/test/tools/llvm-snippy/isa-tests/RISCV/zcmp/err-calls.yaml
+++ b/llvm/test/tools/llvm-snippy/isa-tests/RISCV/zcmp/err-calls.yaml
@@ -5,7 +5,6 @@ options:
   num-instrs: 1000
   honor-target-abi: on
   mattr: +zcmp
-  function-number: 2
   redefine-sp: any-not-SP
 
 include:

--- a/llvm/test/tools/llvm-snippy/liveins-calls.yaml
+++ b/llvm/test/tools/llvm-snippy/liveins-calls.yaml
@@ -6,8 +6,6 @@ options:
   mtriple: riscv64
   num-instrs: 200
   init-regs-in-elf: true
-  function-number: 20
-  function-layers: 5
   verify-mi: true
 
 sections:

--- a/llvm/tools/llvm-snippy/include/snippy/Config/CallGraphLayout.h
+++ b/llvm/tools/llvm-snippy/include/snippy/Config/CallGraphLayout.h
@@ -46,6 +46,10 @@ struct CallGraphLayout {
 
   unsigned getDepth() const { return MaxLayers; }
 };
+
+bool isFunctionLayersSpecified();
+bool isFunctionNumberSpecified();
+
 } // namespace snippy
 
 LLVM_SNIPPY_YAML_DECLARE_MAPPING_TRAITS(snippy::CallGraphLayout);

--- a/llvm/tools/llvm-snippy/lib/Config/CallGraphLayout.cpp
+++ b/llvm/tools/llvm-snippy/lib/Config/CallGraphLayout.cpp
@@ -45,6 +45,10 @@ static snippy::opt<bool>
                    cl::desc("return address register randomization"),
                    cl::Hidden, cl::cat(Options), cl::init(false));
 
+bool isFunctionLayersSpecified() { return FunctionLayers.isSpecified(); }
+
+bool isFunctionNumberSpecified() { return FunctionNumberOpt.isSpecified(); }
+
 CallGraphLayout::CallGraphLayout()
     : MaxLayers(FunctionLayers), FunctionNumber(FunctionNumberOpt),
       InstrNumAncil(NumInstrAncil), RandomizeRA(RandomizeRAOpt) {}

--- a/llvm/tools/llvm-snippy/lib/Config/Config.cpp
+++ b/llvm/tools/llvm-snippy/lib/Config/Config.cpp
@@ -1418,11 +1418,22 @@ static std::string checkSMCConfig(ConfigIOContext &ConfigIOCtx, Config &Info) {
 }
 
 std::string yaml::MappingTraits<Config>::validate(yaml::IO &Io, Config &Info) {
+  if (std::holds_alternative<FunctionDescs>(Info.PassCfg.CGLayout)) {
+    if (snippy::isFunctionNumberSpecified())
+      return "Option \"function-number\" cannot be used together with "
+             "\"call-graph\"";
+
+    if (snippy::isFunctionLayersSpecified())
+      return "Option \"function-layers\" cannot be used together with "
+             "\"call-graph\"";
+  }
+
   if (Info.PassCfg.CodeLayout && !Info.PassCfg.Branches.unaligned())
     return Twine("Code layout feature is only supported with branches "
                  "alignment set to ")
         .concat(Twine(Branchegram::Unaligned))
         .str();
+
   void *Ctx = Io.getContext();
   assert(Ctx && "To parse or output Config provide ConfigIOContext as "
                 "context for yaml::IO");


### PR DESCRIPTION
Fixes #405

Previously, when an explicit call-graph was provided, function-number was
silently ignored instead of being diagnosed as an invalid configuration.

This change rejects configurations that specify an explicit call-graph together
with function-number or function-layers.

Added a regression test based on the reproducer from the issue.

Updated existing tests that used now-invalid config combinations.