### PR TITLE
[snippy] Dump initial registers without model

### DIFF
--- a/llvm/test/tools/llvm-snippy/dump-initial-registers-no-model.yaml
+++ b/llvm/test/tools/llvm-snippy/dump-initial-registers-no-model.yaml
@@ -1,0 +1,20 @@
+# RUN: rm -f %t.initial-regs.yaml
+# RUN: llvm-snippy %s -mtriple=riscv64-unknown-elf -num-instrs=10 \
+# RUN:   --init-regs-in-elf \
+# RUN:   --dump-initial-registers-yaml=%t.initial-regs.yaml
+# RUN: test -s %t.initial-regs.yaml
+
+sections:
+  - name: text
+    VMA: 0x1000
+    LMA: 0x1000
+    SIZE: 0x1000
+    ACCESS: rx
+  - name: data
+    VMA: 0x3000
+    LMA: 0x3000
+    SIZE: 0x1000
+    ACCESS: rw
+
+histogram:
+  - [ADD, 1]

--- a/llvm/test/tools/llvm-snippy/dump-initial-registers-no-model.yaml
+++ b/llvm/test/tools/llvm-snippy/dump-initial-registers-no-model.yaml
@@ -1,20 +1,10 @@
-# RUN: rm -f %t.initial-regs.yaml
-# RUN: llvm-snippy %s -mtriple=riscv64-unknown-elf -num-instrs=10 \
+# RUN: llvm-snippy %s -mtriple=riscv64 --model-plugin=None -num-instrs=10 \
 # RUN:   --init-regs-in-elf \
 # RUN:   --dump-initial-registers-yaml=%t.initial-regs.yaml
 # RUN: test -s %t.initial-regs.yaml
 
-sections:
-  - name: text
-    VMA: 0x1000
-    LMA: 0x1000
-    SIZE: 0x1000
-    ACCESS: rx
-  - name: data
-    VMA: 0x3000
-    LMA: 0x3000
-    SIZE: 0x1000
-    ACCESS: rw
+include:
+  - "Inputs/sections.yaml"
 
 histogram:
   - [ADD, 1]

--- a/llvm/tools/llvm-snippy/include/snippy/Generator/SnippyModule.h
+++ b/llvm/tools/llvm-snippy/include/snippy/Generator/SnippyModule.h
@@ -318,6 +318,10 @@ public:
   const IRegisterState &
   getInitialRegisterState(const TargetSubtargetInfo &ST) const;
 
+  void dumpInitialRegisterState(StringRef YamlPath) const;
+  void dumpInitialRegisterState(StringRef YamlPath,
+                                const TargetSubtargetInfo &ST) const;
+
   const IRegisterState &getInitialRegisterState() const;
 
   bool hasProgramStateSaveSpace() const { return PGSK.get(); }

--- a/llvm/tools/llvm-snippy/include/snippy/Generator/SnippyModule.h
+++ b/llvm/tools/llvm-snippy/include/snippy/Generator/SnippyModule.h
@@ -318,6 +318,8 @@ public:
   const IRegisterState &
   getInitialRegisterState(const TargetSubtargetInfo &ST) const;
 
+  const IRegisterState &getInitialRegisterState() const;
+
   bool hasProgramStateSaveSpace() const { return PGSK.get(); }
   const auto &getProgramStateSaveSpace() const { return *PGSK; }
   auto &getProgramStateSaveSpace() { return *PGSK; }
@@ -363,6 +365,8 @@ private:
   std::unique_ptr<Linker> PLinker;
   std::unique_ptr<MemoryManager> MemManager;
   std::unique_ptr<SMCManagerT> SMCManager;
+
+  const TargetSubtargetInfo *InitialStateSubtarget = nullptr;
 
   constexpr static auto SmallStringDefaultSize = 16;
 

--- a/llvm/tools/llvm-snippy/lib/FlowGenerator.cpp
+++ b/llvm/tools/llvm-snippy/lib/FlowGenerator.cpp
@@ -185,27 +185,6 @@ static auto createSMCInitRoutine(GeneratorContext &Ctx) {
   return ExtModule;
 }
 
-void dumpInitialRegistersIfRequested(SnippyProgramContext &ProgContext,
-                                     LLVMContext &Ctx,
-                                     const PassConfig &PassCfg) {
-  auto &YamlPath = PassCfg.RegistersConfig.InitialStateOutputYaml;
-  if (YamlPath.empty())
-    return;
-
-  if (PassCfg.ModelPluginConfig.runOnModel())
-    return;
-
-  auto &Regs = ProgContext.getInitialRegisterState();
-
-  std::error_code EC;
-  raw_fd_ostream File(YamlPath, EC);
-  if (EC)
-    snippy::fatal(Ctx, "Failed to dump initial registers",
-                  "cannot open file \"" + YamlPath + "\": " + EC.message());
-
-  Regs.saveAsYAMLFile(File);
-}
-
 } // namespace
 
 [[maybe_unused]] static void dumpSelfcheck(const std::vector<char> &Data,
@@ -446,8 +425,6 @@ GeneratorResult FlowGenerator::generate(LLVMState &State,
   if (ProgramCfg.MemoryCfg.SkipRuntimeMemInit)
     Modules = {&MainModule};
 
-  dumpInitialRegistersIfRequested(ProgContext, State.getCtx(), PassCfg);
-
   dumpVerificationIntervalsIfNeeeded(MainModule, GenCtx, BaseFileName);
 
   if (PassCfg.ModelPluginConfig.runOnModel()) {
@@ -526,6 +503,9 @@ GeneratorResult FlowGenerator::generate(LLVMState &State,
           .PCUpdateNotification(TFCfg.LastPC);
 
   } else {
+
+    ProgContext.dumpInitialRegisterState(
+        PassCfg.RegistersConfig.InitialStateOutputYaml);
 
     snippy::warn(WarningName::NoModelExec, State.getCtx(),
                  "Skipping snippet execution on the model",

--- a/llvm/tools/llvm-snippy/lib/FlowGenerator.cpp
+++ b/llvm/tools/llvm-snippy/lib/FlowGenerator.cpp
@@ -185,6 +185,27 @@ static auto createSMCInitRoutine(GeneratorContext &Ctx) {
   return ExtModule;
 }
 
+void dumpInitialRegistersIfRequested(SnippyProgramContext &ProgContext,
+                                     LLVMContext &Ctx,
+                                     const PassConfig &PassCfg) {
+  auto &YamlPath = PassCfg.RegistersConfig.InitialStateOutputYaml;
+  if (YamlPath.empty())
+    return;
+
+  if (PassCfg.ModelPluginConfig.runOnModel())
+    return;
+
+  auto &Regs = ProgContext.getInitialRegisterState();
+
+  std::error_code EC;
+  raw_fd_ostream File(YamlPath, EC);
+  if (EC)
+    snippy::fatal(Ctx, "Failed to dump initial registers",
+                  "cannot open file \"" + YamlPath + "\": " + EC.message());
+
+  Regs.saveAsYAMLFile(File);
+}
+
 } // namespace
 
 [[maybe_unused]] static void dumpSelfcheck(const std::vector<char> &Data,
@@ -424,6 +445,8 @@ GeneratorResult FlowGenerator::generate(LLVMState &State,
     snippy::fatal(EResult.takeError());
   if (ProgramCfg.MemoryCfg.SkipRuntimeMemInit)
     Modules = {&MainModule};
+
+  dumpInitialRegistersIfRequested(ProgContext, State.getCtx(), PassCfg);
 
   dumpVerificationIntervalsIfNeeeded(MainModule, GenCtx, BaseFileName);
 

--- a/llvm/tools/llvm-snippy/lib/Generator/SimulatorContextWrapperPass.cpp
+++ b/llvm/tools/llvm-snippy/lib/Generator/SimulatorContextWrapperPass.cpp
@@ -227,7 +227,7 @@ Error SimulatorContext::runSimulator(const RunInfo &RI) {
   // StartPC location may be updated since last time it was configured.
 
   I.setPC(ElfData->ProgStart);
-  I.dumpCurrentRegState(InitialStateOutputYaml);
+  ProgCtx.dumpInitialRegisterState(InitialStateOutputYaml, I.getSubTarget());
 
   if (ElfData->ProgEnd == std::nullopt)
     return createStringError(

--- a/llvm/tools/llvm-snippy/lib/Generator/SnippyModule.cpp
+++ b/llvm/tools/llvm-snippy/lib/Generator/SnippyModule.cpp
@@ -285,6 +285,31 @@ const IRegisterState &SnippyProgramContext::getInitialRegisterState(
   return *InitialMachineState;
 }
 
+void SnippyProgramContext::dumpInitialRegisterState(
+    StringRef YamlPath, const TargetSubtargetInfo &ST) const {
+  if (YamlPath.empty())
+    return;
+
+  std::error_code EC;
+  raw_fd_ostream File(YamlPath, EC);
+  if (EC)
+    snippy::fatal(State->getCtx(), "Failed to dump initial registers",
+                  "cannot open file \"" + Twine(YamlPath) +
+                      "\": " + EC.message());
+
+  getInitialRegisterState(ST).saveAsYAMLFile(File);
+}
+
+void SnippyProgramContext::dumpInitialRegisterState(StringRef YamlPath) const {
+  if (YamlPath.empty())
+    return;
+
+  assert(
+      InitialStateSubtarget &&
+      "Initial register state requested before target context initialization");
+  dumpInitialRegisterState(YamlPath, *InitialStateSubtarget);
+}
+
 const IRegisterState &SnippyProgramContext::getInitialRegisterState() const {
   assert(InitialStateSubtarget &&
          "Initial register state requested before target context "

--- a/llvm/tools/llvm-snippy/lib/Generator/SnippyModule.cpp
+++ b/llvm/tools/llvm-snippy/lib/Generator/SnippyModule.cpp
@@ -285,6 +285,13 @@ const IRegisterState &SnippyProgramContext::getInitialRegisterState(
   return *InitialMachineState;
 }
 
+const IRegisterState &SnippyProgramContext::getInitialRegisterState() const {
+  assert(InitialStateSubtarget &&
+         "Initial register state requested before target context "
+         "initialization");
+  return getInitialRegisterState(*InitialStateSubtarget);
+}
+
 SnippyProgramContext::SnippyProgramContext(LLVMState &State,
                                            RegisterGenerator &RegGen,
                                            std::vector<RegPool> Pools,
@@ -318,6 +325,7 @@ void SnippyProgramContext::createTargetContext(const Config &Cfg,
                                                const TargetSubtargetInfo &STI,
                                                const RegPoolWrapper &RP) {
   assert(!TargetContext && "Double context insertion");
+  InitialStateSubtarget = &STI;
   TargetContext =
       State->getSnippyTarget().createTargetContext(*State, Cfg, &STI, RP);
 }


### PR DESCRIPTION
Fixes #12

Previously, initial register state was dumped only through the simulator path.

As a result, --dump-initial-registers-yaml did not work when model-plugin was
set to None, even though the initial register state was already available.

This change dumps the initial register state directly in the no-model path.

Added a regression test based on the reproducer from the issue.