### PR TITLE
[snippy] Implement base register groups in burst

### DIFF
--- a/llvm/test/tools/llvm-snippy/base-register-groups/Inputs/burst-base-register-groups-implicit-group.yaml
+++ b/llvm/test/tools/llvm-snippy/base-register-groups/Inputs/burst-base-register-groups-implicit-group.yaml
@@ -1,0 +1,22 @@
+options:
+    mtriple: riscv64-unknown-elf
+    dump-mf: on
+    num-instrs: 200
+    mattr: +zicbom
+
+include:
+  - ../../Inputs/sections.yaml
+
+histogram:
+    - [CBO_INVAL, 1.0]
+    - [LW, 1.0]
+    - [SW, 1.0]
+
+burst:
+    mode: custom
+    min-size: 200
+    max-size: 200
+    groupings:
+      - [CBO_INVAL, LW, SW]
+    base-register-groups:
+      - [CBO_INVAL, SW]

--- a/llvm/test/tools/llvm-snippy/base-register-groups/Inputs/burst-base-register-groups.yaml
+++ b/llvm/test/tools/llvm-snippy/base-register-groups/Inputs/burst-base-register-groups.yaml
@@ -1,0 +1,21 @@
+options:
+    mtriple: riscv64-unknown-elf
+    dump-mf: on
+    num-instrs: 200
+
+include:
+  - ../../Inputs/sections.yaml
+
+histogram:
+    - [LW, 1.0]
+    - [SW, 1.0]
+
+burst:
+    mode: custom
+    min-size: 200
+    max-size: 200
+    groupings:
+      - [LW, SW]
+    base-register-groups:
+      - [SW]
+      - [LW]

--- a/llvm/test/tools/llvm-snippy/base-register-groups/burst-base-register-groups-implicit-group.yaml
+++ b/llvm/test/tools/llvm-snippy/base-register-groups/burst-base-register-groups-implicit-group.yaml
@@ -1,0 +1,6 @@
+# RUN: llvm-snippy %S/Inputs/burst-base-register-groups-implicit-group.yaml \
+# RUN:    -model-plugin=None |& FileCheck %s
+
+# CHECK: LW [[REG:\$x[0-9]+]],
+# CHECK-NOT: CBO-INVAL [[REG]],
+# CHECK-NOT: SW {{\$x[0-9]+}}, [[REG]],

--- a/llvm/test/tools/llvm-snippy/base-register-groups/burst-base-register-groups-intersection.yaml
+++ b/llvm/test/tools/llvm-snippy/base-register-groups/burst-base-register-groups-intersection.yaml
@@ -1,0 +1,31 @@
+# RUN: llvm-snippy %s -model-plugin=None |& FileCheck %s
+
+options:
+    mtriple: riscv64-unknown-elf
+    dump-mf: on
+    num-instrs: 300
+    mattr: +zicbom
+
+include:
+  - ../Inputs/sections.yaml
+
+histogram:
+    - [CBO_INVAL, 1.0]
+    - [LW, 1.0]
+    - [SW, 1.0]
+
+burst:
+    mode: custom
+    min-size: 300
+    max-size: 300
+    groupings:
+      - [CBO_INVAL, LW, SW]
+    base-register-groups:
+      - [CBO_INVAL, SW]
+      - [SW, LW]
+
+# CHECK: CBO_INVAL [[REG1:\$x[0-9]+]]{{.*[[:space:]].*}}
+# CHECK: LW [[REG2:\$x[0-9]+]],
+
+# CHECK-NOT: LW [[REG1]],
+# CHECK-NOT: CBO_INVAL [[REG2]]{{.*[[:space:]].*}}

--- a/llvm/test/tools/llvm-snippy/base-register-groups/burst-base-register-groups.yaml
+++ b/llvm/test/tools/llvm-snippy/base-register-groups/burst-base-register-groups.yaml
@@ -1,0 +1,9 @@
+# RUN: llvm-snippy %S/Inputs/burst-base-register-groups.yaml \
+# RUN:   -model-plugin=None |& FileCheck %s
+
+# CHECK: SW {{\$x[0-9]+}}, [[REG1:\$x[0-9]+]],
+# CHECK-NOT: LW [[REG1]],
+
+# CHECK: LW [[REG2:\$x[0-9]+]],
+# CHECK-NOT: SW {{\$x[0-9]+}}, [[REG2]],
+# CHECK-NOT: LW [[REG1]],

--- a/llvm/tools/llvm-snippy/docs/index.rst
+++ b/llvm/tools/llvm-snippy/docs/index.rst
@@ -675,7 +675,7 @@ operations, such as:
     ``ADD + LD; ADD + SD; SUB + LD; SUB + SD``.
 
 -   `^` - Repetition of an opcode/pattern N times. You can specify either a possible range
-    in the format [min : max] or a specific number of repetitions for the pattern. E.g: 
+    in the format [min : max] or a specific number of repetitions for the pattern. E.g:
 
     -  For instance, ``ADD ^ 3`` would signify three consecutive ``ADD`` instructions.
 
@@ -702,7 +702,7 @@ Lets look at a simple example of defining histogram patterns:
 In the example above:
 
 -  The ``AddMul`` histogram can produce one of the following:
-  
+
    - The sequence [ADD MUL]:
 
       ::
@@ -754,7 +754,7 @@ In the example above:
 Now they can be used in the main histogram.
 
 .. code:: yaml
-  
+
    histogram:
      - [pattern: AddMul, 1.0]
      - [pattern: LoadStore, 1.0]
@@ -762,10 +762,10 @@ Now they can be used in the main histogram.
 
 Also, using the ``--define-main-histogram=<Name>`` option, you can override the main
 `histogram` with a histogram from the `histogram-patterns`. If you do not specify it,
-snippy uses the default value (``histogram``).  
+snippy uses the default value (``histogram``).
 
 For example, by providing ``--define-main-histogram=LoadStore``, only the following
-pairs will be generated:  
+pairs will be generated:
 
 ::
 
@@ -1669,6 +1669,39 @@ For example:
    ./llvm-snippy -mtriple=riscv64-linux-gnu -mcpu=generic-rv64 \
       ./yml/layout.yaml ./yml/memory.yaml -model-plugin=None \
       -num-instrs=50 -seed=0 ./yml/burst-store.yaml -o layout.elf
+
+.. _`_base_register_groups`:
+
+Base register groups
+~~~~~~~~~~~~~~~~~~~~
+
+You can specify opcodes of memory-access instructions that share
+a common register for loading the base address. A base-register
+group can be defined as shown in the example below:
+
+.. code:: yaml
+
+   burst:
+     mode: custom
+     min-size: 10
+     max-size: 30
+     groupings:
+       - [ SW, LW, SD, LD ]
+     base-register-groups:
+       - [SW, SD]
+       - [LW, LD]
+
+In the example we define two base-register groups: stores and loads.
+This prevents an instruction in one group from using the base registers
+assigned to the other group (and vice-versa).
+
+.. important::
+
+   All opcodes that appear in the histogram but are not assigned to any
+   base-register group are placed in a single implicit group. Opcodes
+   in this implicit group cannot share registers with any opcodes that
+   belong to an explicit base-register group.
+
 
 
 Advanced Configuration

--- a/llvm/tools/llvm-snippy/include/snippy/Config/BurstGram.h
+++ b/llvm/tools/llvm-snippy/include/snippy/Config/BurstGram.h
@@ -35,8 +35,9 @@ struct BurstGramData final {
   unsigned MinSize = 0;
   unsigned MaxSize = 0;
   using UniqueOpcodesTy = std::set<unsigned>;
-  using GroupingsTy = std::vector<UniqueOpcodesTy>;
-  std::optional<GroupingsTy> Groupings = std::nullopt;
+  using OpcodeGroupsTy = std::vector<UniqueOpcodesTy>;
+  std::optional<OpcodeGroupsTy> Groupings = std::nullopt;
+  std::optional<OpcodeGroupsTy> BaseRegisterGroups = std::nullopt;
   using OpcodeToNumGroupsTy = std::map<unsigned, unsigned>;
   // Returns a mapping from opcode to the number of burst groups it is used in.
   OpcodeToNumGroupsTy getOpcodeToNumBurstGroups() const {

--- a/llvm/tools/llvm-snippy/lib/Config/BurstGram.cpp
+++ b/llvm/tools/llvm-snippy/lib/Config/BurstGram.cpp
@@ -18,7 +18,7 @@ void BurstGramData::convertToCustomMode(const OpcodeHistogram &Histogram,
     return;
   assert(!Groupings &&
          "Groupings are specified but burst mode is not \"custom\"");
-  Groupings = BurstGramData::GroupingsTy();
+  Groupings = BurstGramData::OpcodeGroupsTy();
   auto CopyFirstIfSatisfies = [&Histogram](auto &Cont, auto &&Cond) {
     copy_if(make_first_range(Histogram.topOpcodes()),
             std::inserter(Cont, Cont.end()), Cond);

--- a/llvm/tools/llvm-snippy/lib/Config/Config.cpp
+++ b/llvm/tools/llvm-snippy/lib/Config/Config.cpp
@@ -57,19 +57,22 @@ void yaml::ScalarEnumerationTraits<BurstMode>::enumeration(yaml::IO &IO,
 }
 
 template <> struct yaml::MappingTraits<BurstGramData> {
-  struct NormalizedGroupings final {
-    std::vector<SList> Groupings;
+  enum class GroupKinds { Groupings, BaseRegisterGroups };
 
-    NormalizedGroupings(yaml::IO &) {}
+  template <GroupKinds Kind> struct NormalizedOpcodeGroups final {
+    std::vector<SList> OpcodeGroups;
 
-    NormalizedGroupings(
-        yaml::IO &IO, const std::optional<BurstGramData::GroupingsTy> &Denorm) {
+    NormalizedOpcodeGroups(yaml::IO &) {}
+
+    NormalizedOpcodeGroups(
+        yaml::IO &IO,
+        const std::optional<BurstGramData::OpcodeGroupsTy> &Denorm) {
       if (Denorm.has_value()) {
         void *Ctx = IO.getContext();
         assert(Ctx && "To parse or output BurstGram provide ConfigIOContext as "
                       "context for yaml::IO");
         const auto &OpCC = static_cast<const ConfigIOContext *>(Ctx)->OpCC;
-        transform(*Denorm, std::back_inserter(Groupings),
+        transform(*Denorm, std::back_inserter(OpcodeGroups),
                   [&OpCC](const auto &Set) {
                     SList Res;
                     transform(Set, std::back_inserter(Res),
@@ -81,14 +84,38 @@ template <> struct yaml::MappingTraits<BurstGramData> {
       }
     }
 
-    std::optional<BurstGramData::GroupingsTy> denormalize(yaml::IO &IO) {
-      BurstGramData::GroupingsTy Denorm;
+    BurstGramData::OpcodeGroupsTy
+    getKindDependentGroups(const BurstGramData::OpcodeGroupsTy &Denorm,
+                           const OpcodeHistogram &Hist,
+                           const OpcodeCache &OpCC) const {
+      if constexpr (Kind == GroupKinds::Groupings)
+        return {};
+      else {
+        assert(Kind == GroupKinds::BaseRegisterGroups);
+        auto IsNotContainedInAnyGroup = [&Denorm](auto Opcode) {
+          return all_of(Denorm, [&Opcode](const auto &Group) {
+            return !Group.count(Opcode);
+          });
+        };
+        auto NotSpecifiedOpcodes = make_filter_range(
+            make_first_range(Hist.topOpcodes()), IsNotContainedInAnyGroup);
+        return {BurstGramData::UniqueOpcodesTy(NotSpecifiedOpcodes.begin(),
+                                               NotSpecifiedOpcodes.end())};
+      }
+    }
+
+    std::optional<BurstGramData::OpcodeGroupsTy> denormalize(yaml::IO &IO) {
+      if (OpcodeGroups.empty())
+        return std::nullopt;
+      BurstGramData::OpcodeGroupsTy Denorm;
       void *Ctx = IO.getContext();
       assert(Ctx && "To parse or output BurstGram provide ConfigIOContext as "
                     "context for yaml::IO");
-      const auto &OpCC = static_cast<const ConfigIOContext *>(Ctx)->OpCC;
+      const auto &CfgCtx = *static_cast<const ConfigIOContext *>(Ctx);
+      const auto &OpCC = CfgCtx.OpCC;
+      const auto &Hist = CfgCtx.Histogram;
       transform(
-          Groupings, std::back_inserter(Denorm), [&OpCC](const auto &Vec) {
+          OpcodeGroups, std::back_inserter(Denorm), [&OpCC](const auto &Vec) {
             std::set<unsigned> Res;
             transform(Vec, std::inserter(Res, Res.end()),
                       [OpCC](const std::string &Name) {
@@ -102,8 +129,7 @@ template <> struct yaml::MappingTraits<BurstGramData> {
                       });
             return Res;
           });
-      if (Denorm.empty())
-        return std::nullopt;
+      append_range(Denorm, getKindDependentGroups(Denorm, Hist, OpCC));
       return Denorm;
     }
   };
@@ -112,10 +138,15 @@ template <> struct yaml::MappingTraits<BurstGramData> {
     IO.mapRequired("min-size", Burst.MinSize);
     IO.mapRequired("max-size", Burst.MaxSize);
     IO.mapRequired("mode", Burst.Mode);
-    yaml::MappingNormalization<NormalizedGroupings,
-                               std::optional<BurstGramData::GroupingsTy>>
+    yaml::MappingNormalization<NormalizedOpcodeGroups<GroupKinds::Groupings>,
+                               std::optional<BurstGramData::OpcodeGroupsTy>>
         Keys(IO, Burst.Groupings);
-    IO.mapOptional("groupings", Keys->Groupings);
+    IO.mapOptional("groupings", Keys->OpcodeGroups);
+    yaml::MappingNormalization<
+        NormalizedOpcodeGroups<GroupKinds::BaseRegisterGroups>,
+        std::optional<BurstGramData::OpcodeGroupsTy>>
+        BaseRegsNorm(IO, Burst.BaseRegisterGroups);
+    IO.mapOptional("base-register-groups", BaseRegsNorm->OpcodeGroups);
   }
 
   static std::string validate(yaml::IO &IO, BurstGramData &Burst) {
@@ -1007,6 +1038,10 @@ void yaml::MappingTraits<Config>::mapping(yaml::IO &IO, Config &Info) {
   yaml::MappingTraits<MemoryScheme>::mapping(IO, Info.CommonPolicyCfg->MS);
   IO.mapOptional("branches", Info.PassCfg.Branches);
 
+  mapOpcodeHistogram(IO, Info);
+
+  // Map burst after the opcode histogram, since it may require generating an
+  // implicit base‑register group.
   // TODO: get rid of this.
   if (!IO.outputting()) {
     std::optional<BurstGramData> BurstData;
@@ -1020,7 +1055,6 @@ void yaml::MappingTraits<Config>::mapping(yaml::IO &IO, Config &Info) {
       IO.mapRequired("burst", Info.BurstConfig->Burst);
   }
 
-  mapOpcodeHistogram(IO, Info);
   IO.mapOptional("selfcheck", Info.CommonPolicyCfg->TrackCfg.Selfcheck);
 
   yaml::MappingNormalization<ImmediateHistogramNormalization,

--- a/llvm/tools/llvm-snippy/lib/Generator/GenerationUtils.cpp
+++ b/llvm/tools/llvm-snippy/lib/Generator/GenerationUtils.cpp
@@ -7,6 +7,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "snippy/Generator/GenerationUtils.h"
+#include "snippy/Config/Config.h"
 #include "snippy/Config/RegisterAccess.h"
 #include "snippy/Generator/MemAccessInfo.h"
 #include "snippy/Generator/Policy.h"
@@ -18,6 +19,8 @@
 #include "llvm/ADT/STLExtras.h"
 #include "llvm/CodeGen/MachineLoopInfo.h"
 #include "llvm/Support/Debug.h"
+
+#include <functional>
 
 namespace llvm {
 namespace snippy {
@@ -586,6 +589,70 @@ collectAddressRestrictions(ArrayRef<unsigned> Opcodes,
   return OpcodeToAR;
 }
 
+using BRGroupRefTy =
+    std::reference_wrapper<const BurstGramData::UniqueOpcodesTy>;
+static BRGroupRefTy
+selectBRGroupWithOpcode(const BurstGramData::OpcodeGroupsTy &BaseRegisterGroups,
+                        unsigned Opcode) {
+  auto DoesNotContainOpcode = [&Opcode](auto GroupRef) {
+    return !GroupRef.count(Opcode);
+  };
+  auto ExpectedGroup = RandEngine::selectFromContainerFiltered(
+      BaseRegisterGroups, DoesNotContainOpcode);
+  assert(ExpectedGroup && "Each opcode must appear in at least one group");
+  return std::cref(*ExpectedGroup);
+}
+
+static unsigned
+selectBaseRegForOpcode(unsigned Opcode,
+                       std::unordered_map<unsigned, BRGroupRefTy> &RegToBRGroup,
+                       ArrayRef<unsigned> AvailableRegs) {
+  // A register is allowed for an opcode if it is bound to a base‑register
+  // group that contains the opcode, or if it is not bound to any group.
+  auto IsAllowed = [&RegToBRGroup, &Opcode](auto Reg) -> bool {
+    if (!RegToBRGroup.count(Reg))
+      return true;
+    auto GroupRef = RegToBRGroup.find(Reg)->second;
+    return GroupRef.get().count(Opcode);
+  };
+
+  auto ExpectedReg = RandEngine::selectFromContainerFiltered(
+      AvailableRegs, std::not_fn(IsAllowed));
+  if (!ExpectedReg)
+    snippy::fatal("Failed to select base register for burst group",
+                  formatv("No available registers for {0} opcode", Opcode));
+  return *ExpectedReg;
+}
+
+static std::vector<unsigned>
+generateBaseRegsForOpcodes(InstructionGenerationContext &IGC,
+                           ArrayRef<unsigned> Opcodes,
+                           ArrayRef<unsigned> AvailableRegs) {
+  std::vector<unsigned> Res(Opcodes.size());
+
+  if (!IGC.hasCfg<BurstPolicyConfig>() ||
+      !IGC.getCfg<BurstPolicyConfig>().Burst.BaseRegisterGroups) {
+    std::generate(Res.begin(), Res.end(), [&AvailableRegs]() {
+      return RandEngine::selectFromContainer(AvailableRegs);
+    });
+    return Res;
+  }
+
+  const auto &BaseRegsGroups =
+      *IGC.getCfg<BurstPolicyConfig>().Burst.BaseRegisterGroups;
+  std::unordered_map<unsigned, BRGroupRefTy> RegToBRGroup;
+  transform(Opcodes, Res.begin(), [&](auto Opcode) {
+    auto Reg = selectBaseRegForOpcode(Opcode, RegToBRGroup, AvailableRegs);
+    // Bind the selected register to some base-register-group that
+    // contains this opcode
+    if (!RegToBRGroup.count(Reg))
+      RegToBRGroup.emplace(Reg,
+                           selectBRGroupWithOpcode(BaseRegsGroups, Opcode));
+    return Reg;
+  });
+  return Res;
+}
+
 std::vector<unsigned>
 generateBaseRegs(InstructionGenerationContext &InstrGenCtx,
                  ArrayRef<unsigned> Opcodes) {
@@ -677,11 +744,7 @@ generateBaseRegs(InstructionGenerationContext &InstrGenCtx,
   // (`BaseRegToAI` as we've already had a mapping from opcode index to the base
   // register). Gathered information gives us restriction on the offset
   // immediate for each base register for each opcode.
-  std::vector<unsigned> OpcodeIdxToBaseReg(Opcodes.size());
-  std::generate(
-      OpcodeIdxToBaseReg.begin(), OpcodeIdxToBaseReg.end(),
-      [&AddrRegs]() { return RandEngine::selectFromContainer(AddrRegs); });
-  return OpcodeIdxToBaseReg;
+  return generateBaseRegsForOpcodes(InstrGenCtx, Opcodes, AddrRegs);
 }
 
 // Collect addresses that will meet the specified restrictions. We call such


### PR DESCRIPTION
[snippy] Implement base register groups in burst

Adds the ability to specify opcodes that can share a common base register within a burst group.