### PR TITLE
Add basic ELEN check to detect illegal LMUL-SEW combinations

### DIFF
--- a/llvm/test/tools/llvm-snippy/rvv-config-biased/conf-all.yaml
+++ b/llvm/test/tools/llvm-snippy/rvv-config-biased/conf-all.yaml
@@ -1,24 +1,11 @@
-# COM: this is the test for default value of snippy-riscv-rvv-wa-exclude-vlmax1
+# COM: this is the test for checking the amount of all valid combinations of listed parameters
 # RUN: llvm-snippy %s %S/Inputs/rvv-unit-all.yaml -mtriple=riscv64 -mattr=+v \
 # RUN:  -model-plugin=None --num-instrs=10 -o %t \
 # RUN:  -riscv-dump-rvv-config \
-# RUN:  |& FileCheck %s --check-prefix=CHECK-FULL-VLMAX1-DISABLED
-
-# RUN: llvm-snippy %s %S/Inputs/rvv-unit-all.yaml -mtriple=riscv64 -mattr=+v \
-# RUN:  -model-plugin=None --num-instrs=10 -o %t \
-# RUN:  -riscv-dump-rvv-config \
-# RUN:  --snippy-riscv-rvv-wa-exclude-vlmax1=true \
-# RUN:  |& FileCheck %s --check-prefix=CHECK-FULL-VLMAX1-DISABLED
-
-# RUN: llvm-snippy %s %S/Inputs/rvv-unit-all.yaml -mtriple=riscv64 -mattr=+v \
-# RUN:  --model-plugin None \
-# RUN:  --num-instrs=10 -o %t \
-# RUN:  -riscv-dump-rvv-config \
-# RUN:  --snippy-riscv-rvv-wa-exclude-vlmax1=false \
-# RUN:  |& FileCheck %s --check-prefix=CHECK-FULL-VLMAX1-ENABLED
+# RUN:  |& FileCheck %s
 
 # RUN: llvm-snippy %S/Inputs/layout-cl-options-rvv.yaml \
-# RUN:  -model-plugin=None |& FileCheck %s --check-prefix=CHECK-FULL-VLMAX1-DISABLED
+# RUN:  -model-plugin=None |& FileCheck %s
 
 
 sections:
@@ -41,37 +28,20 @@ histogram:
 
     - [VADD_VV, 1.0]
 
-# CHECK-FULL-VLMAX1-DISABLED:       --- RVV Configuration Info ---
-# CHECK-FULL-VLMAX1-DISABLED-NEXT:  - Derived VLEN: 128 (VLENB = 16)
-# CHECK-FULL-VLMAX1-DISABLED-NEXT:  - Mode Change Decision Policy: Configuration Bias
-# CHECK-FULL-VLMAX1-DISABLED-NEXT:  - Mode Change Probability: 0.167
-# CHECK-FULL-VLMAX1-DISABLED-NEXT:    Set Vill Bit Probability: 0
-# CHECK-FULL-VLMAX1-DISABLED-NEXT:  - VL Selection Rules:
-# CHECK-FULL-VLMAX1-DISABLED-NEXT:    P: 0.66667 <max_encodable>
-# CHECK-FULL-VLMAX1-DISABLED-NEXT:    P: 0.33333 <any_legal>
-# CHECK-FULL-VLMAX1-DISABLED-NEXT:  - VM Selection Rules:
-# CHECK-FULL-VLMAX1-DISABLED-NEXT:    P: 0.66667 <all_ones>
-# CHECK-FULL-VLMAX1-DISABLED-NEXT:    P: 0.33333 <any_legal>
-# CHECK-FULL-VLMAX1-DISABLED:  - Configuration Bag Listing:
-# CHECK-FULL-VLMAX1-DISABLED-COUNT-352:   /MaxVL
-# CHECK-FULL-VLMAX1-DISABLED-NEXT:  - Configuration Bag Size: 352
-# CHECK-FULL-VLMAX1-DISABLED-NEXT:  - State Cardinality: 7552 ~ {MASKS}
-# CHECK-FULL-VLMAX1-DISABLED-NEXT: --- RVV Configuration End  ---
-
-# CHECK-FULL-VLMAX1-ENABLED:       --- RVV Configuration Info ---
-# CHECK-FULL-VLMAX1-ENABLED-NEXT:  - Derived VLEN: 128 (VLENB = 16)
-# CHECK-FULL-VLMAX1-ENABLED-NEXT:  - Mode Change Decision Policy: Configuration Bias
-# CHECK-FULL-VLMAX1-ENABLED-NEXT:  - Mode Change Probability: 0.167
-# CHECK-FULL-VLMAX1-ENABLED-NEXT:    Set Vill Bit Probability: 0
-# CHECK-FULL-VLMAX1-ENABLED-NEXT:  - VL Selection Rules:
-# CHECK-FULL-VLMAX1-ENABLED-NEXT:    P: 0.66667 <max_encodable>
-# CHECK-FULL-VLMAX1-ENABLED-NEXT:    P: 0.33333 <any_legal>
-# CHECK-FULL-VLMAX1-ENABLED-NEXT:  - VM Selection Rules:
-# CHECK-FULL-VLMAX1-ENABLED-NEXT:    P: 0.66667 <all_ones>
-# CHECK-FULL-VLMAX1-ENABLED-NEXT:    P: 0.33333 <any_legal>
-# CHECK-FULL-VLMAX1-ENABLED:  - Configuration Bag Listing:
-# CHECK-FULL-VLMAX1-ENABLED-COUNT-400:   /MaxVL
-# CHECK-FULL-VLMAX1-ENABLED-NEXT:  - Configuration Bag Size: 400
-# CHECK-FULL-VLMAX1-ENABLED-NEXT:  - State Cardinality: 7600 ~ {MASKS}
-# CHECK-FULL-VLMAX1-ENABLED-NEXT: --- RVV Configuration End  ---
-# CHECK-FULL-VLMAX1-ENABLED: Skipping snippet execution on the model: model was set to 'None'
+# CHECK:       --- RVV Configuration Info ---
+# CHECK-NEXT:  - Derived VLEN: 128 (VLENB = 16)
+# CHECK-NEXT:  - Mode Change Decision Policy: Configuration Bias
+# CHECK-NEXT:  - Mode Change Probability: 0.167
+# CHECK-NEXT:    Set Vill Bit Probability: 0
+# CHECK-NEXT:  - VL Selection Rules:
+# CHECK-NEXT:    P: 0.66667 <max_encodable>
+# CHECK-NEXT:    P: 0.33333 <any_legal>
+# CHECK-NEXT:  - VM Selection Rules:
+# CHECK-NEXT:    P: 0.66667 <all_ones>
+# CHECK-NEXT:    P: 0.33333 <any_legal>
+# CHECK:  - Configuration Bag Listing:
+# CHECK-COUNT-352:   /MaxVL
+# CHECK-NEXT:  - Configuration Bag Size: 352
+# CHECK-NEXT:  - State Cardinality: 7552 ~ {MASKS}
+# CHECK-NEXT: --- RVV Configuration End  ---
+# CHECK: Skipping snippet execution on the model: model was set to 'None'

--- a/llvm/test/tools/llvm-snippy/rvv-config-biased/conf-sew64-lmul1.yaml
+++ b/llvm/test/tools/llvm-snippy/rvv-config-biased/conf-sew64-lmul1.yaml
@@ -3,18 +3,6 @@
 # RUN:  -riscv-dump-rvv-config \
 # RUN:  |& FileCheck %s --check-prefix=CHECK-SEW64
 
-# RUN: llvm-snippy %s -mtriple=riscv64 -mattr=+v \
-# RUN:  -model-plugin=None --num-instrs=10 -o %t \
-# RUN:  -riscv-dump-rvv-config \
-# RUN:  --snippy-riscv-rvv-wa-exclude-vlmax1=true \
-# RUN:  |& FileCheck %s --check-prefix=CHECK-SEW64
-
-# RUN: llvm-snippy %s -mtriple=riscv64 -mattr=+v \
-# RUN:  -model-plugin=None --num-instrs=10 -o %t \
-# RUN:  -riscv-dump-rvv-config \
-# RUN:  --snippy-riscv-rvv-wa-exclude-vlmax1=false \
-# RUN:  |& FileCheck %s --check-prefix=CHECK-SEW64
-
 include:
 - Inputs/rvv-unit-sew64-lmul1.yaml
 

--- a/llvm/test/tools/llvm-snippy/rvv-config-biased/conf-sew64-lmulX.yaml
+++ b/llvm/test/tools/llvm-snippy/rvv-config-biased/conf-sew64-lmulX.yaml
@@ -1,20 +1,7 @@
 # RUN: llvm-snippy %s -mtriple=riscv64 -mattr=+v \
 # RUN:  -model-plugin=None --num-instrs=10 -o %t \
 # RUN:  -riscv-dump-rvv-config \
-# RUN:  |& FileCheck %s --check-prefix=CHECK-SEW64-LMULX-VLMAX1-DISABLED
-
-# RUN: llvm-snippy %s -mtriple=riscv64 -mattr=+v \
-# RUN:  -model-plugin=None --num-instrs=10 -o %t \
-# RUN:  -riscv-dump-rvv-config \
-# RUN:  --snippy-riscv-rvv-wa-exclude-vlmax1=true \
-# RUN:  |& FileCheck %s --check-prefix=CHECK-SEW64-LMULX-VLMAX1-DISABLED
-
-# RUN: llvm-snippy %s -mtriple=riscv64 -mattr=+v \
-# RUN:  --model-plugin None \
-# RUN:  --num-instrs=10 -o %t \
-# RUN:  -riscv-dump-rvv-config \
-# RUN:  --snippy-riscv-rvv-wa-exclude-vlmax1=false \
-# RUN:  |& FileCheck %s --check-prefix=CHECK-SEW64-LMULX-VLMAX1-ENABLED
+# RUN:  |& FileCheck %s
 
 include:
 - Inputs/rvv-unit-sew64-lmulX.yaml
@@ -39,44 +26,23 @@ histogram:
 
     - [VADD_VV, 1.0]
 
-# CHECK-SEW64-LMULX-VLMAX1-DISABLED:      --- RVV Configuration Info ---
-# CHECK-SEW64-LMULX-VLMAX1-DISABLED-NEXT:  - Derived VLEN: 128 (VLENB = 16)
-# CHECK-SEW64-LMULX-VLMAX1-DISABLED-NEXT:  - Mode Change Decision Policy: Configuration Bias
-# CHECK-SEW64-LMULX-VLMAX1-DISABLED-NEXT:  - Mode Change Probability: 0.5
-# CHECK-SEW64-LMULX-VLMAX1-DISABLED-NEXT:    Set Vill Bit Probability: 0
-# CHECK-SEW64-LMULX-VLMAX1-DISABLED-NEXT:  - VL Selection Rules:
-# CHECK-SEW64-LMULX-VLMAX1-DISABLED-NEXT:    P: 0.66667 <max_encodable>
-# CHECK-SEW64-LMULX-VLMAX1-DISABLED-NEXT:    P: 0.33333 <any_legal>
-# CHECK-SEW64-LMULX-VLMAX1-DISABLED-NEXT:  - VM Selection Rules:
-# CHECK-SEW64-LMULX-VLMAX1-DISABLED-NEXT:    P: 0.66667 <all_ones>
-# CHECK-SEW64-LMULX-VLMAX1-DISABLED-NEXT:    P: 0.33333 <any_legal>
-# CHECK-SEW64-LMULX-VLMAX1-DISABLED:  - Configuration Bag Listing:
-# CHECK-SEW64-LMULX-VLMAX1-DISABLED-NEXT:    P: 0.25 Conf: { e64, m1, tu, mu, vxrm: rnu }/MaxVL: 2
-# CHECK-SEW64-LMULX-VLMAX1-DISABLED-NEXT:    P: 0.25 Conf: { e64, m2, tu, mu, vxrm: rnu }/MaxVL: 4
-# CHECK-SEW64-LMULX-VLMAX1-DISABLED-NEXT:    P: 0.25 Conf: { e64, m4, tu, mu, vxrm: rnu }/MaxVL: 8
-# CHECK-SEW64-LMULX-VLMAX1-DISABLED-NEXT:    P: 0.25 Conf: { e64, m8, tu, mu, vxrm: rnu }/MaxVL: 16
-# CHECK-SEW64-LMULX-VLMAX1-DISABLED-NEXT:  - Configuration Bag Size: 4
-# CHECK-SEW64-LMULX-VLMAX1-DISABLED-NEXT:  - State Cardinality: 30 ~ {MASKS}
-# CHECK-SEW64-LMULX-VLMAX1-DISABLED-NEXT: --- RVV Configuration End  ---
-
-# CHECK-SEW64-LMULX-VLMAX1-ENABLED:      --- RVV Configuration Info ---
-# CHECK-SEW64-LMULX-VLMAX1-ENABLED-NEXT:  - Derived VLEN: 128 (VLENB = 16)
-# CHECK-SEW64-LMULX-VLMAX1-ENABLED-NEXT:  - Mode Change Decision Policy: Configuration Bias
-# CHECK-SEW64-LMULX-VLMAX1-ENABLED-NEXT:  - Mode Change Probability: 0.5
-# CHECK-SEW64-LMULX-VLMAX1-ENABLED-NEXT:    Set Vill Bit Probability: 0
-# CHECK-SEW64-LMULX-VLMAX1-ENABLED-NEXT:  - VL Selection Rules:
-# CHECK-SEW64-LMULX-VLMAX1-ENABLED-NEXT:    P: 0.66667 <max_encodable>
-# CHECK-SEW64-LMULX-VLMAX1-ENABLED-NEXT:    P: 0.33333 <any_legal>
-# CHECK-SEW64-LMULX-VLMAX1-ENABLED-NEXT:  - VM Selection Rules:
-# CHECK-SEW64-LMULX-VLMAX1-ENABLED-NEXT:    P: 0.66667 <all_ones>
-# CHECK-SEW64-LMULX-VLMAX1-ENABLED-NEXT:    P: 0.33333 <any_legal>
-# CHECK-SEW64-LMULX-VLMAX1-ENABLED:  - Configuration Bag Listing:
-# CHECK-SEW64-LMULX-VLMAX1-ENABLED-NEXT:    P: 0.22222 Conf: { e64, m1, tu, mu, vxrm: rnu }/MaxVL: 2
-# CHECK-SEW64-LMULX-VLMAX1-ENABLED-NEXT:    P: 0.22222 Conf: { e64, m2, tu, mu, vxrm: rnu }/MaxVL: 4
-# CHECK-SEW64-LMULX-VLMAX1-ENABLED-NEXT:    P: 0.22222 Conf: { e64, m4, tu, mu, vxrm: rnu }/MaxVL: 8
-# CHECK-SEW64-LMULX-VLMAX1-ENABLED-NEXT:    P: 0.22222 Conf: { e64, m8, tu, mu, vxrm: rnu }/MaxVL: 16
-# CHECK-SEW64-LMULX-VLMAX1-ENABLED-NEXT:    P: 0.11111 Conf: { e64, mf2, tu, mu, vxrm: rnu }/MaxVL: 1
-# CHECK-SEW64-LMULX-VLMAX1-ENABLED-NEXT:  - Configuration Bag Size: 5
-# CHECK-SEW64-LMULX-VLMAX1-ENABLED-NEXT:  - State Cardinality: 31 ~ {MASKS}
-# CHECK-SEW64-LMULX-VLMAX1-ENABLED-NEXT: --- RVV Configuration End  ---
-# CHECK-SEW64-LMULX-VLMAX1-ENABLED: Skipping snippet execution on the model: model was set to 'None'
+# CHECK:      --- RVV Configuration Info ---
+# CHECK-NEXT:  - Derived VLEN: 128 (VLENB = 16)
+# CHECK-NEXT:  - Mode Change Decision Policy: Configuration Bias
+# CHECK-NEXT:  - Mode Change Probability: 0.5
+# CHECK-NEXT:    Set Vill Bit Probability: 0
+# CHECK-NEXT:  - VL Selection Rules:
+# CHECK-NEXT:    P: 0.66667 <max_encodable>
+# CHECK-NEXT:    P: 0.33333 <any_legal>
+# CHECK-NEXT:  - VM Selection Rules:
+# CHECK-NEXT:    P: 0.66667 <all_ones>
+# CHECK-NEXT:    P: 0.33333 <any_legal>
+# CHECK:  - Configuration Bag Listing:
+# CHECK-NEXT:    P: 0.25 Conf: { e64, m1, tu, mu, vxrm: rnu }/MaxVL: 2
+# CHECK-NEXT:    P: 0.25 Conf: { e64, m2, tu, mu, vxrm: rnu }/MaxVL: 4
+# CHECK-NEXT:    P: 0.25 Conf: { e64, m4, tu, mu, vxrm: rnu }/MaxVL: 8
+# CHECK-NEXT:    P: 0.25 Conf: { e64, m8, tu, mu, vxrm: rnu }/MaxVL: 16
+# CHECK-NEXT:  - Configuration Bag Size: 4
+# CHECK-NEXT:  - State Cardinality: 30 ~ {MASKS}
+# CHECK-NEXT: --- RVV Configuration End  ---
+# CHECK: Skipping snippet execution on the model: model was set to 'None'

--- a/llvm/test/tools/llvm-snippy/rvv-config-biased/conf-sew8-lmul4.yaml
+++ b/llvm/test/tools/llvm-snippy/rvv-config-biased/conf-sew8-lmul4.yaml
@@ -4,18 +4,6 @@
 # RUN:  |& FileCheck %s --check-prefix=CHECK-SEW8
 
 # RUN: llvm-snippy %s -mtriple=riscv64 -mattr=+v \
-# RUN:  -model-plugin=None --num-instrs=10 -o %t \
-# RUN:  -riscv-dump-rvv-config \
-# RUN:  --snippy-riscv-rvv-wa-exclude-vlmax1=true \
-# RUN:  |& FileCheck %s --check-prefix=CHECK-SEW8
-
-# RUN: llvm-snippy %s -mtriple=riscv64 -mattr=+v \
-# RUN:  -model-plugin=None --num-instrs=10 -o %t \
-# RUN:  -riscv-dump-rvv-config \
-# RUN:  --snippy-riscv-rvv-wa-exclude-vlmax1=false \
-# RUN:  |& FileCheck %s --check-prefix=CHECK-SEW8
-
-# RUN: llvm-snippy %s -mtriple=riscv64 -mattr=+v \
 # RUN:  -model-plugin=None --num-instrs=1 -o %t \
 # RUN:  -riscv-dump-rvv-config \
 # RUN:  |& FileCheck %s --check-prefix=CHECK-SEW8

--- a/llvm/test/tools/llvm-snippy/rvv-config-histogram/conf-all.yaml
+++ b/llvm/test/tools/llvm-snippy/rvv-config-histogram/conf-all.yaml
@@ -1,21 +1,8 @@
-# COM: this is the test for default value of snippy-riscv-rvv-wa-exclude-vlmax1
+# COM: this is the test for checking the amount of all valid combinations of listed parameters
 # RUN: llvm-snippy %s -mtriple=riscv64 -mattr=+v \
 # RUN:  -model-plugin=None --num-instrs=10 -o %t \
 # RUN:  -riscv-dump-rvv-config \
-# RUN:  |& FileCheck %s --check-prefix=CHECK-FULL-VLMAX1-DISABLED
-
-# RUN: llvm-snippy %s -mtriple=riscv64 -mattr=+v \
-# RUN:  -model-plugin=None --num-instrs=10 -o %t \
-# RUN:  -riscv-dump-rvv-config \
-# RUN:  --snippy-riscv-rvv-wa-exclude-vlmax1=true \
-# RUN:  |& FileCheck %s --check-prefix=CHECK-FULL-VLMAX1-DISABLED
-
-# RUN: llvm-snippy %s -mtriple=riscv64 -mattr=+v \
-# RUN:  --model-plugin None \
-# RUN:  --num-instrs=10 -o %t \
-# RUN:  -riscv-dump-rvv-config \
-# RUN:  --snippy-riscv-rvv-wa-exclude-vlmax1=false \
-# RUN:  |& FileCheck %s --check-prefix=CHECK-FULL-VLMAX1-ENABLED
+# RUN:  |& FileCheck %s
 
 include:
 - Inputs/rvv-unit-all.yaml
@@ -43,37 +30,20 @@ histogram:
     - [VSETVL, 1.0]
     - [VADD_VV, 1.0]
 
-# CHECK-FULL-VLMAX1-DISABLED:       --- RVV Configuration Info ---
-# CHECK-FULL-VLMAX1-DISABLED-NEXT:  - Derived VLEN: 128 (VLENB = 16)
-# CHECK-FULL-VLMAX1-DISABLED-NEXT:  - Mode Change Decision Policy: Histogram
-# CHECK-FULL-VLMAX1-DISABLED-NEXT:  - Mode Change Probability: 0
-# CHECK-FULL-VLMAX1-DISABLED-NEXT:    Set Vill Bit Probability: 0
-# CHECK-FULL-VLMAX1-DISABLED-NEXT:  - VL Selection Rules:
-# CHECK-FULL-VLMAX1-DISABLED-NEXT:    P: 0.66667 <max_encodable>
-# CHECK-FULL-VLMAX1-DISABLED-NEXT:    P: 0.33333 <any_legal>
-# CHECK-FULL-VLMAX1-DISABLED-NEXT:  - VM Selection Rules:
-# CHECK-FULL-VLMAX1-DISABLED-NEXT:    P: 0.66667 <all_ones>
-# CHECK-FULL-VLMAX1-DISABLED-NEXT:    P: 0.33333 <any_legal>
-# CHECK-FULL-VLMAX1-DISABLED:  - Configuration Bag Listing:
-# CHECK-FULL-VLMAX1-DISABLED-COUNT-352:   /MaxVL
-# CHECK-FULL-VLMAX1-DISABLED-NEXT:  - Configuration Bag Size: 352
-# CHECK-FULL-VLMAX1-DISABLED-NEXT:  - State Cardinality: 7552 ~ {MASKS}
-# CHECK-FULL-VLMAX1-DISABLED-NEXT: --- RVV Configuration End  ---
-
-# CHECK-FULL-VLMAX1-ENABLED:       --- RVV Configuration Info ---
-# CHECK-FULL-VLMAX1-ENABLED-NEXT:  - Derived VLEN: 128 (VLENB = 16)
-# CHECK-FULL-VLMAX1-ENABLED-NEXT:  - Mode Change Decision Policy: Histogram
-# CHECK-FULL-VLMAX1-ENABLED-NEXT:  - Mode Change Probability: 0
-# CHECK-FULL-VLMAX1-ENABLED-NEXT:    Set Vill Bit Probability: 0
-# CHECK-FULL-VLMAX1-ENABLED-NEXT:  - VL Selection Rules:
-# CHECK-FULL-VLMAX1-ENABLED-NEXT:    P: 0.66667 <max_encodable>
-# CHECK-FULL-VLMAX1-ENABLED-NEXT:    P: 0.33333 <any_legal>
-# CHECK-FULL-VLMAX1-ENABLED-NEXT:  - VM Selection Rules:
-# CHECK-FULL-VLMAX1-ENABLED-NEXT:    P: 0.66667 <all_ones>
-# CHECK-FULL-VLMAX1-ENABLED-NEXT:    P: 0.33333 <any_legal>
-# CHECK-FULL-VLMAX1-ENABLED:  - Configuration Bag Listing:
-# CHECK-FULL-VLMAX1-ENABLED-COUNT-400:   /MaxVL
-# CHECK-FULL-VLMAX1-ENABLED-NEXT:  - Configuration Bag Size: 400
-# CHECK-FULL-VLMAX1-ENABLED-NEXT:  - State Cardinality: 7600 ~ {MASKS}
-# CHECK-FULL-VLMAX1-ENABLED-NEXT: --- RVV Configuration End  ---
-# CHECK-FULL-VLMAX1-ENABLED: Skipping snippet execution on the model: model was set to 'None'
+# CHECK:       --- RVV Configuration Info ---
+# CHECK-NEXT:  - Derived VLEN: 128 (VLENB = 16)
+# CHECK-NEXT:  - Mode Change Decision Policy: Histogram
+# CHECK-NEXT:  - Mode Change Probability: 0
+# CHECK-NEXT:    Set Vill Bit Probability: 0
+# CHECK-NEXT:  - VL Selection Rules:
+# CHECK-NEXT:    P: 0.66667 <max_encodable>
+# CHECK-NEXT:    P: 0.33333 <any_legal>
+# CHECK-NEXT:  - VM Selection Rules:
+# CHECK-NEXT:    P: 0.66667 <all_ones>
+# CHECK-NEXT:    P: 0.33333 <any_legal>
+# CHECK:  - Configuration Bag Listing:
+# CHECK-COUNT-352:   /MaxVL
+# CHECK-NEXT:  - Configuration Bag Size: 352
+# CHECK-NEXT:  - State Cardinality: 7552 ~ {MASKS}
+# CHECK-NEXT: --- RVV Configuration End  ---
+# CHECK: Skipping snippet execution on the model: model was set to 'None'

--- a/llvm/test/tools/llvm-snippy/rvv-config-histogram/conf-sew64-lmul1.yaml
+++ b/llvm/test/tools/llvm-snippy/rvv-config-histogram/conf-sew64-lmul1.yaml
@@ -3,18 +3,6 @@
 # RUN:  -riscv-dump-rvv-config \
 # RUN:  |& FileCheck %s --check-prefix=CHECK-SEW64
 
-# RUN: llvm-snippy %s -mtriple=riscv64 -mattr=+v \
-# RUN:  -model-plugin=None --num-instrs=10 -o %t \
-# RUN:  -riscv-dump-rvv-config \
-# RUN:  --snippy-riscv-rvv-wa-exclude-vlmax1=true \
-# RUN:  |& FileCheck %s --check-prefix=CHECK-SEW64
-
-# RUN: llvm-snippy %s -mtriple=riscv64 -mattr=+v \
-# RUN:  -model-plugin=None --num-instrs=10 -o %t \
-# RUN:  -riscv-dump-rvv-config \
-# RUN:  --snippy-riscv-rvv-wa-exclude-vlmax1=false \
-# RUN:  |& FileCheck %s --check-prefix=CHECK-SEW64
-
 include:
 - Inputs/rvv-unit-sew64-lmul1.yaml
 

--- a/llvm/test/tools/llvm-snippy/rvv-config-histogram/conf-sew64-lmulX.yaml
+++ b/llvm/test/tools/llvm-snippy/rvv-config-histogram/conf-sew64-lmulX.yaml
@@ -1,20 +1,7 @@
 # RUN: llvm-snippy %s -mtriple=riscv64 -mattr=+v \
 # RUN:  -model-plugin=None --num-instrs=10 -o %t \
 # RUN:  -riscv-dump-rvv-config \
-# RUN:  |& FileCheck %s --check-prefix=CHECK-SEW64-LMULX-VLMAX1-DISABLED
-
-# RUN: llvm-snippy %s -mtriple=riscv64 -mattr=+v \
-# RUN:  -model-plugin=None --num-instrs=10 -o %t \
-# RUN:  -riscv-dump-rvv-config \
-# RUN:  --snippy-riscv-rvv-wa-exclude-vlmax1=true \
-# RUN:  |& FileCheck %s --check-prefix=CHECK-SEW64-LMULX-VLMAX1-DISABLED
-
-# RUN: llvm-snippy %s -mtriple=riscv64 -mattr=+v \
-# RUN:  --model-plugin None \
-# RUN:  --num-instrs=10 -o %t \
-# RUN:  -riscv-dump-rvv-config \
-# RUN:  --snippy-riscv-rvv-wa-exclude-vlmax1=false \
-# RUN:  |& FileCheck %s --check-prefix=CHECK-SEW64-LMULX-VLMAX1-ENABLED
+# RUN:  |& FileCheck %s
 
 include:
 - Inputs/rvv-unit-sew64-lmulX.yaml
@@ -42,44 +29,23 @@ histogram:
     - [VSETVL, 1.0]
     - [VADD_VV, 1.0]
 
-# CHECK-SEW64-LMULX-VLMAX1-DISABLED:      --- RVV Configuration Info ---
-# CHECK-SEW64-LMULX-VLMAX1-DISABLED-NEXT:  - Derived VLEN: 128 (VLENB = 16)
-# CHECK-SEW64-LMULX-VLMAX1-DISABLED-NEXT:  - Mode Change Decision Policy: Histogram
-# CHECK-SEW64-LMULX-VLMAX1-DISABLED-NEXT:  - Mode Change Probability: 0
-# CHECK-SEW64-LMULX-VLMAX1-DISABLED-NEXT:    Set Vill Bit Probability: 0
-# CHECK-SEW64-LMULX-VLMAX1-DISABLED-NEXT:  - VL Selection Rules:
-# CHECK-SEW64-LMULX-VLMAX1-DISABLED-NEXT:    P: 0.66667 <max_encodable>
-# CHECK-SEW64-LMULX-VLMAX1-DISABLED-NEXT:    P: 0.33333 <any_legal>
-# CHECK-SEW64-LMULX-VLMAX1-DISABLED-NEXT:  - VM Selection Rules:
-# CHECK-SEW64-LMULX-VLMAX1-DISABLED-NEXT:    P: 0.66667 <all_ones>
-# CHECK-SEW64-LMULX-VLMAX1-DISABLED-NEXT:    P: 0.33333 <any_legal>
-# CHECK-SEW64-LMULX-VLMAX1-DISABLED:  - Configuration Bag Listing:
-# CHECK-SEW64-LMULX-VLMAX1-DISABLED-NEXT:    P: 0.25 Conf: { e64, m1, tu, mu, vxrm: rnu }/MaxVL: 2
-# CHECK-SEW64-LMULX-VLMAX1-DISABLED-NEXT:    P: 0.25 Conf: { e64, m2, tu, mu, vxrm: rnu }/MaxVL: 4
-# CHECK-SEW64-LMULX-VLMAX1-DISABLED-NEXT:    P: 0.25 Conf: { e64, m4, tu, mu, vxrm: rnu }/MaxVL: 8
-# CHECK-SEW64-LMULX-VLMAX1-DISABLED-NEXT:    P: 0.25 Conf: { e64, m8, tu, mu, vxrm: rnu }/MaxVL: 16
-# CHECK-SEW64-LMULX-VLMAX1-DISABLED-NEXT:  - Configuration Bag Size: 4
-# CHECK-SEW64-LMULX-VLMAX1-DISABLED-NEXT:  - State Cardinality: 30 ~ {MASKS}
-# CHECK-SEW64-LMULX-VLMAX1-DISABLED-NEXT: --- RVV Configuration End  ---
-
-# CHECK-SEW64-LMULX-VLMAX1-ENABLED:      --- RVV Configuration Info ---
-# CHECK-SEW64-LMULX-VLMAX1-ENABLED-NEXT:  - Derived VLEN: 128 (VLENB = 16)
-# CHECK-SEW64-LMULX-VLMAX1-ENABLED-NEXT:  - Mode Change Decision Policy: Histogram
-# CHECK-SEW64-LMULX-VLMAX1-ENABLED-NEXT:  - Mode Change Probability: 0
-# CHECK-SEW64-LMULX-VLMAX1-ENABLED-NEXT:    Set Vill Bit Probability: 0
-# CHECK-SEW64-LMULX-VLMAX1-ENABLED-NEXT:  - VL Selection Rules:
-# CHECK-SEW64-LMULX-VLMAX1-ENABLED-NEXT:    P: 0.66667 <max_encodable>
-# CHECK-SEW64-LMULX-VLMAX1-ENABLED-NEXT:    P: 0.33333 <any_legal>
-# CHECK-SEW64-LMULX-VLMAX1-ENABLED-NEXT:  - VM Selection Rules:
-# CHECK-SEW64-LMULX-VLMAX1-ENABLED-NEXT:    P: 0.66667 <all_ones>
-# CHECK-SEW64-LMULX-VLMAX1-ENABLED-NEXT:    P: 0.33333 <any_legal>
-# CHECK-SEW64-LMULX-VLMAX1-ENABLED:  - Configuration Bag Listing:
-# CHECK-SEW64-LMULX-VLMAX1-ENABLED-NEXT:    P: 0.22222 Conf: { e64, m1, tu, mu, vxrm: rnu }/MaxVL: 2
-# CHECK-SEW64-LMULX-VLMAX1-ENABLED-NEXT:    P: 0.22222 Conf: { e64, m2, tu, mu, vxrm: rnu }/MaxVL: 4
-# CHECK-SEW64-LMULX-VLMAX1-ENABLED-NEXT:    P: 0.22222 Conf: { e64, m4, tu, mu, vxrm: rnu }/MaxVL: 8
-# CHECK-SEW64-LMULX-VLMAX1-ENABLED-NEXT:    P: 0.22222 Conf: { e64, m8, tu, mu, vxrm: rnu }/MaxVL: 16
-# CHECK-SEW64-LMULX-VLMAX1-ENABLED-NEXT:    P: 0.11111 Conf: { e64, mf2, tu, mu, vxrm: rnu }/MaxVL: 1
-# CHECK-SEW64-LMULX-VLMAX1-ENABLED-NEXT:  - Configuration Bag Size: 5
-# CHECK-SEW64-LMULX-VLMAX1-ENABLED-NEXT:  - State Cardinality: 31 ~ {MASKS}
-# CHECK-SEW64-LMULX-VLMAX1-ENABLED-NEXT: --- RVV Configuration End  ---
-# CHECK-SEW64-LMULX-VLMAX1-ENABLED: Skipping snippet execution on the model: model was set to 'None'
+# CHECK:      --- RVV Configuration Info ---
+# CHECK-NEXT:  - Derived VLEN: 128 (VLENB = 16)
+# CHECK-NEXT:  - Mode Change Decision Policy: Histogram
+# CHECK-NEXT:  - Mode Change Probability: 0
+# CHECK-NEXT:    Set Vill Bit Probability: 0
+# CHECK-NEXT:  - VL Selection Rules:
+# CHECK-NEXT:    P: 0.66667 <max_encodable>
+# CHECK-NEXT:    P: 0.33333 <any_legal>
+# CHECK-NEXT:  - VM Selection Rules:
+# CHECK-NEXT:    P: 0.66667 <all_ones>
+# CHECK-NEXT:    P: 0.33333 <any_legal>
+# CHECK:  - Configuration Bag Listing:
+# CHECK-NEXT:    P: 0.25 Conf: { e64, m1, tu, mu, vxrm: rnu }/MaxVL: 2
+# CHECK-NEXT:    P: 0.25 Conf: { e64, m2, tu, mu, vxrm: rnu }/MaxVL: 4
+# CHECK-NEXT:    P: 0.25 Conf: { e64, m4, tu, mu, vxrm: rnu }/MaxVL: 8
+# CHECK-NEXT:    P: 0.25 Conf: { e64, m8, tu, mu, vxrm: rnu }/MaxVL: 16
+# CHECK-NEXT:  - Configuration Bag Size: 4
+# CHECK-NEXT:  - State Cardinality: 30 ~ {MASKS}
+# CHECK-NEXT: --- RVV Configuration End  ---
+# CHECK: Skipping snippet execution on the model: model was set to 'None'

--- a/llvm/test/tools/llvm-snippy/rvv-config-histogram/conf-sew8-lmul4.yaml
+++ b/llvm/test/tools/llvm-snippy/rvv-config-histogram/conf-sew8-lmul4.yaml
@@ -3,18 +3,6 @@
 # RUN:  -riscv-dump-rvv-config \
 # RUN:  |& FileCheck %s --check-prefix=CHECK-SEW8
 
-# RUN: llvm-snippy %s -mtriple=riscv64 -mattr=+v \
-# RUN:  -model-plugin=None --num-instrs=10 -o %t \
-# RUN:  -riscv-dump-rvv-config \
-# RUN:  --snippy-riscv-rvv-wa-exclude-vlmax1=true \
-# RUN:  |& FileCheck %s --check-prefix=CHECK-SEW8
-
-# RUN: llvm-snippy %s -mtriple=riscv64 -mattr=+v \
-# RUN:  -model-plugin=None --num-instrs=10 -o %t \
-# RUN:  -riscv-dump-rvv-config \
-# RUN:  --snippy-riscv-rvv-wa-exclude-vlmax1=false \
-# RUN:  |& FileCheck %s --check-prefix=CHECK-SEW8
-
 include:
 - Inputs/rvv-unit-sew8-lmul4.yaml
 

--- a/llvm/test/tools/llvm-snippy/rvv-config-histogram/legal-configurations-lmul-sew-elen64.yaml
+++ b/llvm/test/tools/llvm-snippy/rvv-config-histogram/legal-configurations-lmul-sew-elen64.yaml
@@ -1,0 +1,45 @@
+# REQUIRES: riscv-rvv
+# COM: The test checks that only valid configurations for ELEN=64 are generated.
+
+# RUN: llvm-snippy %s \
+# RUN: |& FileCheck %s
+
+options:
+  mtriple: riscv64
+  march: "rv64gv_zvl1024b"
+  snippy-riscv-simplified-vector-bits-max: 1024
+  num-instrs: 1
+  riscv-dump-rvv-config: ""
+
+include:
+  - "Inputs/rvv-unit-all.yaml"
+  - "Inputs/sections.yaml"
+
+histogram:
+       - [VSETIVLI, 1.0]
+       - [VSETVL, 1.0]
+       - [VSETVLI, 1.0]
+       - [VADD_VV, 1.0]
+
+# CHECK: --- RVV Configuration Info ---
+# CHECK-NEXT:   - Derived VLEN: 1024 (VLENB = 128)
+# CHECK-NEXT:   - Mode Change Decision Policy: Histogram
+# CHECK-NEXT:   - Mode Change Probability: 0.750 (vsetvl/vsetvli/vsetivli=0.250/0.250/0.250)
+# CHECK-NEXT:     Set Vill Bit Probability: 0
+# CHECK-NEXT:   - VL Selection Rules:
+# CHECK-NEXT:     P: 0.66667 <max_encodable>
+# CHECK-NEXT:     P: 0.33333 <any_legal>
+# CHECK-NEXT:   - VM Selection Rules:
+# CHECK-NEXT:     P: 0.66667 <all_ones>
+# CHECK-NEXT:     P: 0.33333 <any_legal>
+  
+# CHECK: - Configuration Bag Listing:
+# CHECK-NOT: Conf: { e64, mf2
+# CHECK-NOT: Conf: { e64, mf4
+# CHECK-NOT: Conf: { e64, mf8
+# CHECK-NOT: Conf: { e32, mf4
+# CHECK-NOT: Conf: { e32, mf8
+# CHECK-NOT: Conf: { e16, mf8
+# CHECK:   - Configuration Bag Size: 352
+# CHECK-NEXT:   - State Cardinality: 60416 ~ {MASKS} 
+# CHECK-NEXT: --- RVV Configuration End  ---

--- a/llvm/tools/llvm-snippy/lib/Target/RISCV/RVVUnitConfig.cpp
+++ b/llvm/tools/llvm-snippy/lib/Target/RISCV/RVVUnitConfig.cpp
@@ -61,13 +61,6 @@ static snippy::opt<unsigned> SimplifiedRVV_VLEN(
              "(the default) RVV configuration is active."),
     cl::Hidden, cl::init(128), cl::cat(SnippyRISCVOptions));
 
-static snippy::opt<bool> ExcludeVLMAXOne(
-    "snippy-riscv-rvv-wa-exclude-vlmax1",
-    cl::desc("Excludes cases when VLMAX is 1 (happens when LMUL is < 1). "
-             "Currently, it seems that our SW models do not handle this case "
-             "correctly."),
-    cl::Hidden, cl::init(true), cl::cat(SnippyRISCVOptions));
-
 static snippy::opt<bool> NoReservedCfgRVV(
     "riscv-disable-reserved-sew-lmul",
     cl::desc(
@@ -277,7 +270,7 @@ using RVVConfigPoint =
     ProbableElement<std::tuple<VSEW, VLMUL, VMAMode, VTAMode, VXRMMode>>;
 
 static InternalConfigurationPoint
-convertRepresentation(unsigned VLEN, const RVVConfigPoint &Point) {
+convertRepresentation(unsigned ELEN, unsigned VLEN, const RVVConfigPoint &Point) {
   InternalConfigurationPoint Result;
   Result.Probability = Point.Prob;
   Result.Config.SEW = std::get<VSEW>(Point.Element);
@@ -288,7 +281,7 @@ convertRepresentation(unsigned VLEN, const RVVConfigPoint &Point) {
       (std::get<VTAMode>(Point.Element) == VTAMode::TA);
   Result.Config.VXRM = std::get<VXRMMode>(Point.Element);
 
-  auto MaxVL = computeVLMax(VLEN, static_cast<unsigned>(Result.Config.SEW),
+  auto MaxVL = computeVLMax(ELEN, VLEN, static_cast<unsigned>(Result.Config.SEW),
                             Result.Config.LMUL);
   if (MaxVL == 0)
     Result.Config.IsLegal = false;
@@ -299,9 +292,9 @@ static unsigned getMaxPossibleVL(unsigned VLEN) {
   return VLEN * RVVConfiguration::getMaxLMUL() / RVVConfiguration::getMinSEW();
 }
 
-static unsigned generateMaxVL(unsigned VLEN, const RVVConfiguration &Cfg) {
+static unsigned generateMaxVL(unsigned ELEN, unsigned VLEN, const RVVConfiguration &Cfg) {
   auto PointSEW = static_cast<unsigned>(Cfg.SEW);
-  auto MaxVL = computeVLMax(VLEN, PointSEW, Cfg.LMUL);
+  auto MaxVL = computeVLMax(ELEN, VLEN, PointSEW, Cfg.LMUL);
   if (MaxVL > 0)
     return MaxVL;
   // If MaxVL == 0 this means that RVVConfiguration is illegal
@@ -314,8 +307,8 @@ struct MaxPossibleVLGen final : VLGeneratorInterface {
   static constexpr const char *kID = "max_encodable";
   std::string identify() const override { return kID; }
 
-  unsigned generate(unsigned VLEN, const RVVConfiguration &Cfg) const override {
-    return generateMaxVL(VLEN, Cfg);
+  unsigned generate(unsigned ELEN, unsigned VLEN, const RVVConfiguration &Cfg) const override {
+    return generateMaxVL(ELEN, VLEN, Cfg);
   }
 };
 
@@ -327,15 +320,15 @@ struct MaxVLGenerator final : VLGeneratorInterface {
   static constexpr const char *kID = "vlmax";
   std::string identify() const override { return kID; }
 
-  virtual bool isApplicable(unsigned VLEN, bool ReduceVL,
+  virtual bool isApplicable(unsigned ELEN, unsigned VLEN, bool ReduceVL,
                             const RVVConfiguration &Cfg) const override {
     auto PointSEW = static_cast<unsigned>(Cfg.SEW);
-    auto MaxVL = computeVLMax(VLEN, PointSEW, Cfg.LMUL);
+    auto MaxVL = computeVLMax(ELEN, VLEN, PointSEW, Cfg.LMUL);
     return !ReduceVL || (MaxVL <= kMaxVLForVSETIVLI);
   }
 
-  unsigned generate(unsigned VLEN, const RVVConfiguration &Cfg) const override {
-    return generateMaxVL(VLEN, Cfg);
+  unsigned generate(unsigned ELEN, unsigned VLEN, const RVVConfiguration &Cfg) const override {
+    return generateMaxVL(ELEN, VLEN, Cfg);
   }
 };
 
@@ -344,9 +337,9 @@ struct LegalVLGenerator final : VLGeneratorInterface {
   static constexpr const char *kID = "any_legal";
   std::string identify() const override { return kID; }
 
-  unsigned generate(unsigned VLEN, const RVVConfiguration &Cfg) const override {
+  unsigned generate(unsigned ELEN, unsigned VLEN, const RVVConfiguration &Cfg) const override {
     auto PointSEW = static_cast<unsigned>(Cfg.SEW);
-    auto MaxVL = computeVLMax(VLEN, PointSEW, Cfg.LMUL);
+    auto MaxVL = computeVLMax(ELEN, VLEN, PointSEW, Cfg.LMUL);
     if (MaxVL > 0)
       return RandEngine::genInRangeInclusive<unsigned>(0u, MaxVL);
     // If MaxVL == 0 this means that RVVConfiguration is illegal
@@ -361,9 +354,9 @@ struct LegalVLNonZeroGenerator final : VLGeneratorInterface {
   static constexpr const char *kID = "any_legal_non_zero";
   std::string identify() const override { return kID; }
 
-  unsigned generate(unsigned VLEN, const RVVConfiguration &Cfg) const override {
+  unsigned generate(unsigned ELEN, unsigned VLEN, const RVVConfiguration &Cfg) const override {
     auto PointSEW = static_cast<unsigned>(Cfg.SEW);
-    auto MaxVL = computeVLMax(VLEN, PointSEW, Cfg.LMUL);
+    auto MaxVL = computeVLMax(ELEN, VLEN, PointSEW, Cfg.LMUL);
     if (MaxVL > 0)
       return RandEngine::genInRangeInclusive<unsigned>(1u, MaxVL);
     // If MaxVL == 0 this means that RVVConfiguration is illegal
@@ -422,15 +415,15 @@ struct ImmVLGen : public VLGeneratorInterface {
   static constexpr const char *kID = "imm";
   std::string identify() const override { return Context; }
 
-  bool isApplicable(unsigned VLEN, bool ReduceVL,
+  bool isApplicable(unsigned ELEN, unsigned VLEN, bool ReduceVL,
                     const RVVConfiguration &Cfg) const override {
     auto PointSEW = static_cast<unsigned>(Cfg.SEW);
-    auto MaxVL = computeVLMax(VLEN, PointSEW, Cfg.LMUL);
+    auto MaxVL = computeVLMax(ELEN, VLEN, PointSEW, Cfg.LMUL);
     return (Value <= MaxVL) && (!ReduceVL || (Value <= kMaxVLForVSETIVLI));
   }
 
-  unsigned generate(unsigned VLEN, const RVVConfiguration &Cfg) const override {
-    assert(isApplicable(VLEN, /* ReduceVL */ false, Cfg) &&
+  unsigned generate(unsigned ELEN, unsigned VLEN, const RVVConfiguration &Cfg) const override {
+    assert(isApplicable(ELEN, VLEN, /* ReduceVL */ false, Cfg) &&
            "Generation request should be made only for valid VLs");
     return Value;
   }
@@ -762,27 +755,30 @@ std::unique_ptr<RVVConfigInterface> createRVVConfig() {
   return std::make_unique<RVVConfig>();
 }
 
-inline static bool isReservedValues(unsigned SEW, VLMUL LMUL) {
-  return LMUL == VLMUL::LMUL_RESERVED || !isLegalSEW(SEW);
+inline static bool isReservedValues(unsigned ELEN, unsigned SEW, VLMUL LMUL) {
+  if (LMUL == VLMUL::LMUL_RESERVED)
+    return true;
+  auto [Multiplier, IsFractional] = RISCVVType::decodeVLMUL(LMUL);
+  auto MinFracMultiplier = ELEN / SEW;
+  return !isLegalSEW(SEW) || (SEW > ELEN) ||
+    (IsFractional && (Multiplier > MinFracMultiplier));
 }
 
-unsigned computeVLMax(unsigned VLEN, unsigned SEW, VLMUL LMUL) {
-  if (isReservedValues(SEW, LMUL))
+unsigned computeVLMax(unsigned ELEN, unsigned VLEN, unsigned SEW, VLMUL LMUL) {
+  if (isReservedValues(ELEN, SEW, LMUL))
     return 0;
   assert(canBeEncoded(SEW));
   auto [Multiplier, IsFractional] = RISCVVType::decodeVLMUL(LMUL);
   if (IsFractional) {
     auto Result = VLEN / SEW / Multiplier;
-    if ((Result == 1) && ExcludeVLMAXOne)
-      Result = 0;
     return Result;
   }
   return VLEN / SEW * Multiplier;
 }
 
-std::pair<unsigned, bool> computeDecodedEMUL(unsigned SEW, unsigned EEW,
+std::pair<unsigned, bool> computeDecodedEMUL(unsigned ELEN, unsigned SEW, unsigned EEW,
                                              VLMUL LMUL) {
-  if (isReservedValues(SEW, LMUL) || !isLegalSEW(SEW) || !isLegalSEW(EEW)) {
+  if (isReservedValues(ELEN, SEW, LMUL) || !isLegalSEW(SEW) || !isLegalSEW(EEW)) {
     // Calculating EMUL doesn't make sense for illegal values of SEW or LMUL, so
     // just return {1, 0}
     return {1, 0};
@@ -796,13 +792,13 @@ std::pair<unsigned, bool> computeDecodedEMUL(unsigned SEW, unsigned EEW,
   return {Dividend / Divisor, /* fractional */ false};
 }
 
-bool isValidEMUL(unsigned SEW, unsigned EEW, VLMUL LMUL) {
-  auto [EMUL, IsFractional] = computeDecodedEMUL(SEW, EEW, LMUL);
+bool isValidEMUL(unsigned ELEN, unsigned SEW, unsigned EEW, VLMUL LMUL) {
+  auto [EMUL, IsFractional] = computeDecodedEMUL(ELEN, SEW, EEW, LMUL);
   return RISCVVType::isValidLMUL(EMUL, IsFractional);
 }
 
-VLMUL computeEMUL(unsigned SEW, unsigned EEW, VLMUL LMUL) {
-  auto [EMUL, IsFractional] = computeDecodedEMUL(SEW, EEW, LMUL);
+VLMUL computeEMUL(unsigned ELEN, unsigned SEW, unsigned EEW, VLMUL LMUL) {
+  auto [EMUL, IsFractional] = computeDecodedEMUL(ELEN, SEW, EEW, LMUL);
   assert(RISCVVType::isValidLMUL(EMUL, IsFractional));
   return RISCVVType::encodeLMUL(EMUL, IsFractional);
 }
@@ -911,7 +907,7 @@ static void printRawProbabilities(raw_ostream &OS, StringRef Name,
 
 static std::vector<InternalConfigurationPoint> getLegalConfigurationPoints(
     const std::vector<RVVConfigurationInfo::VLGeneratorHolder> &VLGen,
-    unsigned VLEN, const RVVUnitInfo &VUInfo,
+    unsigned ELEN, unsigned VLEN, const RVVUnitInfo &VUInfo,
     std::vector<RVVConfiguration> &DiscardedConfigs, bool IsOnlyVSETIVLI) {
   auto SEW = normalizeWeights(VUInfo.VTYPE.SEW);
   auto LMUL = normalizeWeights(VUInfo.VTYPE.LMUL);
@@ -939,7 +935,7 @@ static std::vector<InternalConfigurationPoint> getLegalConfigurationPoints(
   ConfigPoints.reserve(Points.size());
   std::transform(
       Points.begin(), Points.end(), std::back_inserter(ConfigPoints),
-      [VLEN](const auto &Point) { return convertRepresentation(VLEN, Point); });
+      [ELEN, VLEN](const auto &Point) { return convertRepresentation(ELEN, VLEN, Point); });
 
   // Now, at this moment ConfigPoints can contain illegal configurations
   llvm::erase_if(ConfigPoints, [](const auto &Point) {
@@ -954,10 +950,10 @@ static std::vector<InternalConfigurationPoint> getLegalConfigurationPoints(
   // Also erase all ConfigPoints for which there are no valid VLs
   auto DiscardedIt = std::partition(
       ConfigPoints.begin(), ConfigPoints.end(),
-      [&VLGen, IsOnlyVSETIVLI, VLEN](const auto &Point) {
+      [&VLGen, IsOnlyVSETIVLI, ELEN, VLEN](const auto &Point) {
         return llvm::any_of(
-            VLGen, [VLEN, IsOnlyVSETIVLI, &Point = Point](const auto &VL) {
-              return VL->isApplicable(VLEN, /* ReduceVL */ IsOnlyVSETIVLI,
+            VLGen, [ELEN, VLEN, IsOnlyVSETIVLI, &Point = Point](const auto &VL) {
+              return VL->isApplicable(ELEN, VLEN, /* ReduceVL */ IsOnlyVSETIVLI,
                                       Point.Config);
             });
       });
@@ -969,7 +965,7 @@ static std::vector<InternalConfigurationPoint> getLegalConfigurationPoints(
 }
 
 static std::vector<InternalConfigurationPoint>
-getIllegalConfigurationPoints(unsigned VLEN) {
+getIllegalConfigurationPoints(unsigned ELEN, unsigned VLEN) {
   auto AllSEW = normalizeWeights(
       WeightsArray<SEWEnumList>{1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0});
   auto AllLMUL = normalizeWeights(
@@ -984,13 +980,13 @@ getIllegalConfigurationPoints(unsigned VLEN) {
   std::vector<InternalConfigurationPoint> AllConfigPoints;
   std::transform(
       AllPoints.begin(), AllPoints.end(), std::back_inserter(AllConfigPoints),
-      [VLEN](const auto &Point) { return convertRepresentation(VLEN, Point); });
+      [ELEN, VLEN](const auto &Point) { return convertRepresentation(ELEN, VLEN, Point); });
 
   // Now, at this moment AllConfigPoints contain legal configurations
   llvm::erase_if(
-      AllConfigPoints, [](const auto &Point) {
+      AllConfigPoints, [ELEN](const auto &Point) {
         if (NoReservedCfgRVV &&
-            isReservedValues(static_cast<unsigned>(Point.Config.SEW),
+            isReservedValues(ELEN, static_cast<unsigned>(Point.Config.SEW),
                              Point.Config.LMUL))
           return true;
         return Point.Config.IsLegal;
@@ -1000,11 +996,11 @@ getIllegalConfigurationPoints(unsigned VLEN) {
 
 static std::vector<InternalConfigurationPoint> getAllConfigurationPoints(
     const std::vector<RVVConfigurationInfo::VLGeneratorHolder> &VLGen,
-    unsigned VLEN, const RVVUnitInfo &VUInfo,
+    unsigned ELEN, unsigned VLEN, const RVVUnitInfo &VUInfo,
     std::vector<RVVConfiguration> &DiscardedConfigs, bool IsOnlyVSETIVLI) {
   auto ConfigPoints = getLegalConfigurationPoints(
-      VLGen, VLEN, VUInfo, DiscardedConfigs, IsOnlyVSETIVLI);
-  auto IllegalConfigPoints = getIllegalConfigurationPoints(VLEN);
+      VLGen, ELEN, VLEN, VUInfo, DiscardedConfigs, IsOnlyVSETIVLI);
+  auto IllegalConfigPoints = getIllegalConfigurationPoints(ELEN, VLEN);
   // Merge two arrays with legal and illegal configurations into one common
   ConfigPoints.insert(ConfigPoints.end(), IllegalConfigPoints.begin(),
                       IllegalConfigPoints.end());
@@ -1013,10 +1009,10 @@ static std::vector<InternalConfigurationPoint> getAllConfigurationPoints(
 
 static WeightedItems<RVVConfiguration> getInternalConfigurationPoints(
     const std::vector<RVVConfigurationInfo::VLGeneratorHolder> &VLGen,
-    unsigned VLEN, const RVVUnitInfo &VUInfo, double ProbSetVill,
+    unsigned ELEN, unsigned VLEN, const RVVUnitInfo &VUInfo, double ProbSetVill,
     std::vector<RVVConfiguration> &DiscardedConfigs, bool IsOnlyVSETIVLI) {
   auto ConfigPoints = getAllConfigurationPoints(
-      VLGen, VLEN, VUInfo, DiscardedConfigs, IsOnlyVSETIVLI);
+      VLGen, ELEN, VLEN, VUInfo, DiscardedConfigs, IsOnlyVSETIVLI);
   double WeightLegal = std::accumulate(
       ConfigPoints.begin(), ConfigPoints.end(), 0.0,
       [](const double Weight, const auto &Point) {
@@ -1123,7 +1119,7 @@ getVMsCompatibleWithVLs(
 
 static WeightedItems<RVVConfigurationInfo::VLGeneratorHolder>
 getVLsCompatibleWithVMsAndConfigs(
-    unsigned MinMaxVL, unsigned VLEN,
+    unsigned MinMaxVL, unsigned ELEN, unsigned VLEN,
     const std::vector<RVVConfiguration> &ConfigPoints,
     const std::vector<RVVConfigurationInfo::VMGeneratorHolder> &VMGen,
     WeightedItems<RVVConfigurationInfo::VLGeneratorHolder> &VLGensWeights,
@@ -1138,9 +1134,9 @@ getVLsCompatibleWithVMsAndConfigs(
                      [MinMaxVL, &VLGen = VLGen](auto &VM) {
                        return VM->isApplicable(getMinVLValue(MinMaxVL, VLGen));
                      }) &&
-        llvm::any_of(ConfigPoints, [VLEN, IsOnlyVSETIVLI,
+        llvm::any_of(ConfigPoints, [ELEN, VLEN, IsOnlyVSETIVLI,
                                     &VLGen = VLGen](const auto &Config) {
-          return VLGen->isApplicable(VLEN, /* ReduceVL */ IsOnlyVSETIVLI,
+          return VLGen->isApplicable(ELEN, VLEN, /* ReduceVL */ IsOnlyVSETIVLI,
                                      Config);
         })) {
       Result.addWeightedElement(VLWeight, std::move(VLGen));
@@ -1156,15 +1152,15 @@ getVLsCompatibleWithVMsAndConfigs(
 
 static WeightedItems<RVVConfiguration> getConfigsCompatibleWithVLs(
     const std::vector<RVVConfigurationInfo::VLGeneratorHolder> &VLGen,
-    unsigned VLEN, WeightedItems<RVVConfiguration> &ConfigPointsWeights,
+    unsigned ELEN, unsigned VLEN, WeightedItems<RVVConfiguration> &ConfigPointsWeights,
     std::vector<RVVConfiguration> &DiscardedConfigs, bool IsOnlyVSETIVLI) {
   WeightedItems<RVVConfiguration> Result;
   for (auto &&[Config, ConfigWeight] :
        zip(ConfigPointsWeights.Elements, ConfigPointsWeights.Weights)) {
     // Keep the RVV Configs that have at least one compatible VL
-    if (llvm::any_of(VLGen, [VLEN, IsOnlyVSETIVLI,
+    if (llvm::any_of(VLGen, [ELEN, VLEN, IsOnlyVSETIVLI,
                              &Config = Config](const auto &VL) {
-          return VL->isApplicable(VLEN, /* ReduceVL */ IsOnlyVSETIVLI, Config);
+          return VL->isApplicable(ELEN, VLEN, /* ReduceVL */ IsOnlyVSETIVLI, Config);
         })) {
       Result.addWeightedElement(ConfigWeight, std::move(Config));
       continue;
@@ -1183,6 +1179,7 @@ static bool hasVXRMUsers(const OpcodeHistogram &Hist) {
 }
 
 RVVConfigurationInfo RVVConfigurationInfo::createDefault(const Config &Cfg,
+                                                         unsigned ELEN,
                                                          unsigned VLEN) {
   std::vector<RVVConfiguration> Configurations = {{}};
 
@@ -1198,7 +1195,7 @@ RVVConfigurationInfo RVVConfigurationInfo::createDefault(const Config &Cfg,
   bool NeedsVXRMUpdate = hasVXRMUsers(Cfg.getOpcodeHistogram());
 
   return RVVConfigurationInfo(
-      VLEN,
+      ELEN, VLEN,
       ConfigGenerator(std::move(Configurations), std::vector<double>(1, 1.0)),
       VLGenerator(std::move(VLGen), std::vector<double>(1, 1.0)),
       VMGenerator(std::move(VMGen), std::vector<double>(1, 1.0)),
@@ -1254,19 +1251,19 @@ static void printDiscardedRVVConfigurations(
 }
 
 static unsigned
-extractMinMaxVL(unsigned VLEN,
+extractMinMaxVL(unsigned ELEN, unsigned VLEN,
                 const std::vector<RVVConfiguration> &ConfigPoints) {
   assert(!ConfigPoints.empty());
   std::vector<unsigned> MaxVLs;
   llvm::transform(
-      ConfigPoints, std::back_inserter(MaxVLs), [VLEN](const auto &Point) {
-        return computeVLMax(VLEN, static_cast<unsigned>(Point.SEW), Point.LMUL);
+      ConfigPoints, std::back_inserter(MaxVLs), [ELEN, VLEN](const auto &Point) {
+        return computeVLMax(ELEN, VLEN, static_cast<unsigned>(Point.SEW), Point.LMUL);
       });
   return *llvm::min_element(MaxVLs);
 }
 
 RVVConfigurationInfo RVVConfigurationInfo::buildConfiguration(
-    const Config &Cfg, unsigned VLEN,
+    const Config &Cfg, unsigned ELEN, unsigned VLEN,
     std::unique_ptr<RVVConfigInterface> &&Iface,
     std::vector<VMGeneratorHolder> &DiscardedVMs,
     std::vector<VLGeneratorHolder> &DiscardedVLs,
@@ -1300,9 +1297,9 @@ RVVConfigurationInfo RVVConfigurationInfo::buildConfiguration(
       constructGeneratorsFromWeightedIds<VLGeneratorHolder>(CS.VUInfo.VL);
   // 2. Get all RVV Configs that are compatible with at least one VL
   auto ConfigPointsWeights = getInternalConfigurationPoints(
-      VLGensWeights.Elements, VLEN, CS.VUInfo, CS.Guides.SetVillP,
+      VLGensWeights.Elements, ELEN, VLEN, CS.VUInfo, CS.Guides.SetVillP,
       DiscardedConfigs, IsOnlyVSETIVLI);
-  auto MinMaxVL = extractMinMaxVL(VLEN, ConfigPointsWeights.Elements);
+  auto MinMaxVL = extractMinMaxVL(ELEN, VLEN, ConfigPointsWeights.Elements);
   // 3.1 Get all VMs from the rvv-unit-config
   auto VMGensWeights = constructGeneratorsFromWeightedIds<
       RVVConfigurationInfo::VMGeneratorHolder>(CS.VUInfo.VM);
@@ -1312,13 +1309,13 @@ RVVConfigurationInfo RVVConfigurationInfo::buildConfiguration(
   // 4. Filter out VLs that are incompatible with all remaining VLs and/or all
   // remaining RVV Configs
   auto &&[VLGen, VLWeights] = getVLsCompatibleWithVMsAndConfigs(
-      MinMaxVL, VLEN, ConfigPointsWeights.Elements,
+      MinMaxVL, ELEN, VLEN, ConfigPointsWeights.Elements,
       VMGensWeightsFiltered.Elements, VLGensWeights, DiscardedVLs,
       IsOnlyVSETIVLI);
   // 5. Filter out the RVV Configs that were compatible only with the VLs that
   // were discarded in step 4
   auto &&[ConfigPoints, ConfigWeights] = getConfigsCompatibleWithVLs(
-      VLGen, VLEN, ConfigPointsWeights, DiscardedConfigs, IsOnlyVSETIVLI);
+      VLGen, ELEN, VLEN, ConfigPointsWeights, DiscardedConfigs, IsOnlyVSETIVLI);
   // 6. Filter out the VMs that were compatible only with the VLs that were
   // discarded in step 4
   auto &&[VMGen, VMWeights] = getVMsCompatibleWithVLs(
@@ -1327,20 +1324,21 @@ RVVConfigurationInfo RVVConfigurationInfo::buildConfiguration(
   bool NeedsVXRMUpdate = hasVXRMUsers(Cfg.getOpcodeHistogram());
 
   return RVVConfigurationInfo(
-      VLEN, ConfigGenerator(std::move(ConfigPoints), ConfigWeights),
+      ELEN, VLEN, ConfigGenerator(std::move(ConfigPoints), ConfigWeights),
       VLGenerator(std::move(VLGen), VLWeights),
       VMGenerator(std::move(VMGen), VMWeights), ModeSwitchInfo,
       !CS.Guides.ModeChangeProb.isDeduced(), NeedsVXRMUpdate);
 }
 
 unsigned RVVConfigurationInfo::getVLEN() const { return VLEN; }
+unsigned RVVConfigurationInfo::getELEN() const { return ELEN; }
 
 const RVVConfigurationInfo::VLGeneratorHolder &
 RVVConfigurationInfo::selectVLGen(const RVVConfiguration &Config,
                                   bool ReduceVL) const {
-  auto Filter = [VLEN = getVLEN(), ReduceVL,
+  auto Filter = [ELEN = getELEN(), VLEN = getVLEN(), ReduceVL,
                  &Config](const VLGeneratorHolder &VLGen) {
-    return VLGen->isApplicable(VLEN, ReduceVL, Config);
+    return VLGen->isApplicable(ELEN, VLEN, ReduceVL, Config);
   };
   const auto &ApplicGen = VLGen.generateIf(Filter);
   // Generation under a condition can return a nullopt only if all elements do
@@ -1370,7 +1368,7 @@ RVVConfigurationInfo::selectVMGen(unsigned VL) const {
 RVVConfigurationInfo::VLVM
 RVVConfigurationInfo::selectVLVM(const RVVConfiguration &Config,
                                  bool ReduceVL) const {
-  auto VL = selectVLGen(Config, ReduceVL)->generate(VLEN, Config);
+  auto VL = selectVLGen(Config, ReduceVL)->generate(ELEN, VLEN, Config);
   if (ReduceVL && (VL > kMaxVLForVSETIVLI))
     VL = kMaxVLForVSETIVLI;
   auto VM = selectVMGen(VL)->generate(VL);
@@ -1446,7 +1444,7 @@ void RVVConfigurationInfo::print(raw_ostream &OS) const {
     OS << " Conf: ";
     Point.print(OS);
     OS << "/MaxVL: "
-       << computeVLMax(VLEN, static_cast<unsigned>(Point.SEW), Point.LMUL);
+       << computeVLMax(ELEN, VLEN, static_cast<unsigned>(Point.SEW), Point.LMUL);
     OS << "\n";
   }
   if (IllegalPointsSize > 0) {
@@ -1461,7 +1459,7 @@ void RVVConfigurationInfo::print(raw_ostream &OS) const {
       std::accumulate(CfgGen.elements().begin(), CfgGen.elements().end(),
                       size_t(0), [this](const auto &Acc, const auto &Point) {
                         auto PointSEW = static_cast<unsigned>(Point.SEW);
-                        auto MaxVL = computeVLMax(VLEN, PointSEW, Point.LMUL);
+                        auto MaxVL = computeVLMax(ELEN, VLEN, PointSEW, Point.LMUL);
                         return Acc + MaxVL;
                       });
   OS << "  - State Cardinality: " << Cardinality << " ~ {MASKS} \n";
@@ -1471,10 +1469,10 @@ void RVVConfigurationInfo::print(raw_ostream &OS) const {
 void RVVConfigurationInfo::dump() const { print(dbgs()); }
 
 RVVConfigurationInfo::RVVConfigurationInfo(
-    unsigned VLEN, ConfigGenerator &&CfgGen, VLGenerator &&VLGen,
+    unsigned ELEN, unsigned VLEN, ConfigGenerator &&CfgGen, VLGenerator &&VLGen,
     VMGenerator &&VMGen, const ModeChangeInfo &SwitchInfo, bool EnableGuides,
     bool NeedsVXRMUpdate)
-    : VLEN(VLEN), CfgGen(std::move(CfgGen)), VLGen(std::move(VLGen)),
+    : VLEN(VLEN), ELEN(ELEN), CfgGen(std::move(CfgGen)), VLGen(std::move(VLGen)),
       VMGen(std::move(VMGen)), SwitchInfo(SwitchInfo),
       ArtificialModeChange(EnableGuides), NeedsVXRMUpdate(NeedsVXRMUpdate) {}
 
@@ -1494,9 +1492,9 @@ RISCVConfigurationInfo::constructConfiguration(LLVMState &State,
                         .getRVVConfigurationSpace()
                         .has_value()
                     ? RVVConfigurationInfo::buildConfiguration(
-                          Cfg, ArchInfo.VLEN, nullptr, DiscardedVMs,
+                          Cfg, ArchInfo.ELEN, ArchInfo.VLEN, nullptr, DiscardedVMs,
                           DiscardedVLs, DiscardedConfigs)
-                    : RVVConfigurationInfo::createDefault(Cfg, ArchInfo.VLEN);
+                    : RVVConfigurationInfo::createDefault(Cfg, ArchInfo.VLEN, ArchInfo.VLEN);
 
   if (DumpDiscardedRVVConfigurations.isSpecified())
     printDiscardedRVVConfigurations(DumpDiscardedRVVConfigurations.getValue(),
@@ -1527,6 +1525,8 @@ RISCVConfigurationInfo::deriveArchitecturalInformation(
   if (!ST.hasStdExtV())
     return Result;
 
+  Result.ELEN = ST.getELen();
+  
   if (!UseNonSimplifiedRVVConfig) {
     Result.VLEN = SimplifiedRVV_VLEN;
     return Result;

--- a/llvm/tools/llvm-snippy/lib/Target/RISCV/RVVUnitConfig.h
+++ b/llvm/tools/llvm-snippy/lib/Target/RISCV/RVVUnitConfig.h
@@ -95,10 +95,12 @@ class Config;
 std::unique_ptr<RVVConfigInterface> createRVVConfig();
 
 // Compute EMUL = EEW / SEW * LMUL
-VLMUL computeEMUL(unsigned SEW, unsigned EEW, VLMUL LMUL);
-std::pair<unsigned, bool> computeDecodedEMUL(unsigned SEW, unsigned EEW,
+VLMUL computeEMUL(unsigned ELEN, unsigned SEW, unsigned EEW, VLMUL LMUL);
+std::pair<unsigned, bool> computeDecodedEMUL(unsigned ELEN,
+                                             unsigned SEW,
+                                             unsigned EEW,
                                              VLMUL LMUL);
-bool isValidEMUL(unsigned SEW, unsigned EEW, VLMUL LMUL);
+bool isValidEMUL(unsigned ELEN, unsigned SEW, unsigned EEW, VLMUL LMUL);
 
 inline static bool canBeEncoded(unsigned SEW) {
   // This wrapper clarify the meaning of the function RISCVVType::isValidSEW.
@@ -112,7 +114,7 @@ inline static bool canBeEncoded(unsigned SEW) {
 // LMUL - lmul for which we want to compute VLMAX
 // If function returns zero - it means that such combination is not valid
 // TODO: consider replacing unsigned `SEW` parameter with typed enum
-unsigned computeVLMax(unsigned VLEN, unsigned SEW, VLMUL LMUL);
+unsigned computeVLMax(unsigned ELEN, unsigned VLEN, unsigned SEW, VLMUL LMUL);
 
 struct RVVConfiguration final {
   // Note: integer values are in-sync with RVV spec 1.0
@@ -220,11 +222,11 @@ private:
 
 struct VLGeneratorInterface {
   virtual std::string identify() const = 0;
-  virtual bool isApplicable(unsigned /* VLEN */, bool /* ReduceVL */,
+  virtual bool isApplicable(unsigned /* ELEN */, unsigned /* VLEN */, bool /* ReduceVL */,
                             const RVVConfiguration & /* Cfg */) const {
     return true;
   };
-  virtual unsigned generate(unsigned VLEN,
+  virtual unsigned generate(unsigned ELEN, unsigned VLEN,
                             const RVVConfiguration &Cfg) const = 0;
   virtual ~VLGeneratorInterface(){};
 };
@@ -304,15 +306,16 @@ struct RVVConfigurationInfo final {
   using VLGeneratorHolder = std::unique_ptr<VLGeneratorInterface>;
   using VMGeneratorHolder = std::unique_ptr<VMGeneratorInterface>;
 
-  static RVVConfigurationInfo createDefault(const Config &Cfg, unsigned VLEN);
+  static RVVConfigurationInfo createDefault(const Config &Cfg, unsigned ELEN, unsigned VLEN);
 
   static RVVConfigurationInfo
-  buildConfiguration(const Config &Cfg, unsigned VLEN,
+  buildConfiguration(const Config &Cfg, unsigned ELEN, unsigned VLEN,
                      std::unique_ptr<RVVConfigInterface> &&VU,
                      std::vector<VMGeneratorHolder> &DiscardedVMs,
                      std::vector<VLGeneratorHolder> &DiscardedVLs,
                      std::vector<RVVConfiguration> &DiscardedConfigs);
 
+  unsigned getELEN() const;
   unsigned getVLEN() const;
   unsigned getVLENB() const { return getVLEN() / RISCV_CHAR_BIT; }
 
@@ -340,7 +343,7 @@ private:
   using VLGenerator = DiscreteGeneratorInfo<VLGeneratorHolder>;
   using VMGenerator = DiscreteGeneratorInfo<VMGeneratorHolder>;
 
-  RVVConfigurationInfo(unsigned VLEN, ConfigGenerator &&CfgGen,
+  RVVConfigurationInfo(unsigned ELEN, unsigned VLEN, ConfigGenerator &&CfgGen,
                        VLGenerator &&VLGen, VMGenerator &&VMGen,
                        const ModeChangeInfo &SwitchInfo, bool EnableGuides,
                        bool NeedsVXRMUpdate);
@@ -350,6 +353,7 @@ private:
   const VMGeneratorHolder &selectVMGen(unsigned VL) const;
 
   unsigned VLEN;
+  unsigned ELEN;
   ConfigGenerator CfgGen;
   VLGenerator VLGen;
   VMGenerator VMGen;
@@ -379,6 +383,7 @@ class RISCVConfigurationInfo final {
   struct ArchitecturalInfo {
     unsigned VLEN = 0;
     unsigned XLEN = 0;
+    unsigned ELEN = 0;
   };
 
   BaseConfigurationInfo BaseCfgInfo;

--- a/llvm/tools/llvm-snippy/lib/Target/RISCV/Target.cpp
+++ b/llvm/tools/llvm-snippy/lib/Target/RISCV/Target.cpp
@@ -273,7 +273,7 @@ getElemWidthAndGapForVectorLoad(unsigned Opcode, unsigned EEW,
     // segment and non-indexed loads
     auto SEW = static_cast<unsigned>(RISCVCtx.getSEW(MBB));
     auto [EMUL, IsFractionEMUL] =
-        computeDecodedEMUL(SEW, EEW, RISCVCtx.getLMUL(MBB));
+        computeDecodedEMUL(RISCVCtx.getELEN(), SEW, EEW, RISCVCtx.getLMUL(MBB));
     assert(RISCVVType::isValidLMUL(EMUL, IsFractionEMUL));
     return {EEW, EMUL};
   }
@@ -451,6 +451,7 @@ static bool isLegalRVVInstr(unsigned Opcode, const RVVConfiguration &Cfg,
     return false;
   auto SEW = static_cast<unsigned>(Cfg.SEW);
   auto LMUL = Cfg.LMUL;
+  auto ELEN = ST->getELen();
 
   if (!Cfg.IsLegal) {
     // From RISCV-V spec 1.0:
@@ -472,12 +473,12 @@ static bool isLegalRVVInstr(unsigned Opcode, const RVVConfiguration &Cfg,
       isRVVStridedLoadStore(Opcode)) {
     // EEW is a data element width.
     auto EEW = getDataElementWidth(Opcode) * CHAR_BIT;
-    return isValidEMUL(SEW, EEW, LMUL);
+    return isValidEMUL(ELEN, SEW, EEW, LMUL);
   }
   if (isRVVIndexedLoadStore(Opcode)) {
     // EEW is an index element width.
     auto EEW = getIndexElementWidth(Opcode);
-    return isValidEMUL(SEW, EEW, LMUL);
+    return isValidEMUL(ELEN, SEW, EEW, LMUL);
   }
   // RVV segment loads/stores encodes not only EEW in the opcode, but number of
   // fields (NFIELDS) as well. This introduces one more restriction in addition
@@ -491,9 +492,9 @@ static bool isLegalRVVInstr(unsigned Opcode, const RVVConfiguration &Cfg,
   if (isRVVUnitStrideSegLoadStore(Opcode) || isRVVStridedSegLoadStore(Opcode)) {
     // EEW is a data element width.
     auto EEW = getDataElementWidth(Opcode) * CHAR_BIT;
-    if (!isValidEMUL(SEW, EEW, LMUL))
+    if (!isValidEMUL(ELEN, SEW, EEW, LMUL))
       return false;
-    auto EMUL = computeEMUL(SEW, EEW, LMUL);
+    auto EMUL = computeEMUL(ELEN, SEW, EEW, LMUL);
     auto [Multiplier, IsFractional] = RISCVVType::decodeVLMUL(EMUL);
     if (IsFractional)
       return true;
@@ -501,7 +502,7 @@ static bool isLegalRVVInstr(unsigned Opcode, const RVVConfiguration &Cfg,
   }
   if (isRVVIndexedSegLoadStore(Opcode)) {
     auto EEW = getIndexElementWidth(Opcode);
-    if (!isValidEMUL(SEW, EEW, LMUL))
+    if (!isValidEMUL(ELEN, SEW, EEW, LMUL))
       return false;
     auto [Multiplier, IsFractional] = RISCVVType::decodeVLMUL(LMUL);
     if (IsFractional)
@@ -530,7 +531,7 @@ static bool isLegalRVVInstr(unsigned Opcode, const RVVConfiguration &Cfg,
     auto EEW = SEW / Factor;
     if (!isLegalSEW(EEW))
       return false;
-    return isValidEMUL(SEW, EEW, LMUL);
+    return isValidEMUL(ELEN, SEW, EEW, LMUL);
   }
   if (isRVVIntegerWidening(Opcode) || isRVVFPWidening(Opcode) ||
       isRVVIntegerNarrowing(Opcode) || isRVVFPNarrowing(Opcode)) {
@@ -539,13 +540,13 @@ static bool isLegalRVVInstr(unsigned Opcode, const RVVConfiguration &Cfg,
     if (!isLegalSEW(EEW))
       return false;
     // Check that LMUL * 2 is also legal.
-    return isValidEMUL(SEW, EEW, LMUL);
+    return isValidEMUL(ELEN, SEW, EEW, LMUL);
   }
   if (isRVVGather16(Opcode)) {
     // The vrgatherei16.vv form uses SEW/LMUL for the data in vs2 but EEW=16 and
     // EMUL = (16/SEW)*LMUL for the indices in vs1.
     auto EEW = 16u;
-    return isValidEMUL(SEW, EEW, LMUL);
+    return isValidEMUL(ELEN, SEW, EEW, LMUL);
   }
 
   // Instructions from zvbc (carryless multiplication) extension

--- a/llvm/tools/llvm-snippy/lib/Target/RISCV/TargetGenContext.h
+++ b/llvm/tools/llvm-snippy/lib/Target/RISCV/TargetGenContext.h
@@ -136,6 +136,8 @@ public:
     return CurrentRVVMode.MBBGuard == &MBB;
   }
 
+  auto getELEN() const { return getVUConfigInfo().getELEN(); }
+  
   auto getVLENB() const { return getVUConfigInfo().getVLENB(); }
 
   auto getVLEN() const { return getVUConfigInfo().getVLEN(); }
@@ -173,10 +175,11 @@ public:
         isRVVUnitStrideSegLoadStore(Opcode) || isRVVStridedLoadStore(Opcode) ||
         isRVVStridedSegLoadStore(Opcode)) {
       assert(OpIndex == 0 && "We can be here only for vd vector operand");
+      auto ELEN = getELEN();
       auto LMUL = getLMUL(MBB);
       auto SEW = getSEW(MBB);
       auto EEW = getDataElementWidth(Opcode) * CHAR_BIT;
-      return computeDecodedEMUL(static_cast<unsigned>(SEW), EEW, LMUL);
+      return computeDecodedEMUL(ELEN, static_cast<unsigned>(SEW), EEW, LMUL);
     }
 
     // For Vector Indexed Loads and Stores Instructions EMULs of the operands
@@ -218,10 +221,11 @@ public:
       if (OpIndex == 0)
         return std::make_pair(Multiplier, IsFractional);
       assert(OpIndex == 2 && "We can be here only for index vector operand");
+      auto ELEN = getELEN();
       auto LMUL = getLMUL(MBB);
       auto SEW = static_cast<unsigned>(getSEW(MBB));
       auto EIEW = getIndexElementWidth(Opcode);
-      return computeDecodedEMUL(static_cast<unsigned>(SEW), EIEW, LMUL);
+      return computeDecodedEMUL(ELEN, static_cast<unsigned>(SEW), EIEW, LMUL);
     }
 
     // FIXME: This function must take into account the index of the operand
@@ -257,17 +261,19 @@ public:
     if ((isRVVIntegerWidening(Opcode) || isRVVFPWidening(Opcode) ||
          isRVVIntegerNarrowing(Opcode) || isRVVFPNarrowing(Opcode)) &&
         !IsFractional) {
+      auto ELEN = getELEN();
       auto LMUL = getLMUL(MBB);
       auto SEW = static_cast<unsigned>(getSEW(MBB));
-      return computeDecodedEMUL(SEW, SEW * 2u, LMUL);
+      return computeDecodedEMUL(ELEN, SEW, SEW * 2u, LMUL);
     }
 
     if (isRVVGather16(Opcode)) {
+      auto ELEN = getELEN();
       auto LMUL = getLMUL(MBB);
       auto SEW = static_cast<unsigned>(getSEW(MBB));
       auto EEW = 16u;
       if (EEW > SEW)
-        std::tie(Multiplier, IsFractional) = computeDecodedEMUL(SEW, EEW, LMUL);
+        std::tie(Multiplier, IsFractional) = computeDecodedEMUL(ELEN, SEW, EEW, LMUL);
     }
 
     return std::make_pair(Multiplier, IsFractional);


### PR DESCRIPTION
### Description
This PR address the following issue - https://github.com/syntacore/snippy/issues/445 . The main idea is to mark illegal LMUL-SEW combination as reserved, using the `isReservedValues` function, by checking the current value of ELEN(so it will be correct from the RISC-V specification point of view). The rest of the code is dedicated to the correct propagation of `ELEN` argument from LLVM backend to the `isReservedValues` function.

### Verification
Well, the only way I could verify it just to check with my own rvv-related tests. No invalid LMUL-SEW combination was detected. There are also no new CPP-related warnings, so I guess linter is ok too.

### Related issues
https://github.com/syntacore/snippy/issues/445