### PR TITLE
[snippy] Restrict using SP as any operand in SPRelated instructions.

### DIFF
--- a/llvm/test/tools/llvm-snippy/sp-related-instr-with-op-reinit.yaml
+++ b/llvm/test/tools/llvm-snippy/sp-related-instr-with-op-reinit.yaml
@@ -1,0 +1,20 @@
+# RUN: llvm-snippy --model-plugin=None %s |& FileCheck %s
+
+include:
+    - "Inputs/sections.yaml"
+
+options:
+    mtriple: riscv32
+    march: "rv32ic"
+    num-instrs: 5000
+    dump-mf: true
+
+imm-hist:
+  opcodes:
+    - "C_SWSP": "uniform"
+
+histogram:
+  - [C_SWSP, 10.0]
+
+
+# CHECK-NOT: C_SWSP $x2, $x2, {{[0-9]*}}

--- a/llvm/tools/llvm-snippy/lib/Target/RISCV/Target.cpp
+++ b/llvm/tools/llvm-snippy/lib/Target/RISCV/Target.cpp
@@ -4356,6 +4356,9 @@ public:
     const auto &TgtCtx =
         IGC.ProgCtx.getTargetContext().getImpl<RISCVGeneratorContext>();
 
+    if (isSPRelative(Opcode) && RC.getID() != RISCV::SPRegClassID)
+      return {RISCV::X2};
+
     if (!isRVV(Opcode))
       return {};
 


### PR DESCRIPTION
Fix issue, when SP register is chosen as first operand for SP related
instruction, leading to errors if OperandInitialization is specified.