### PR TITLE
[snippy] implement random scheduling deoptimization

### DIFF
--- a/llvm/test/tools/llvm-snippy/Inputs/random-scheduling/basic.yaml
+++ b/llvm/test/tools/llvm-snippy/Inputs/random-scheduling/basic.yaml
@@ -1,0 +1,3 @@
+scheduling:
+  enabled: true
+  max-region-size: 1000

--- a/llvm/test/tools/llvm-snippy/patterns/histogram-patterns/random-scheduling-with-patterns.yaml
+++ b/llvm/test/tools/llvm-snippy/patterns/histogram-patterns/random-scheduling-with-patterns.yaml
@@ -1,0 +1,108 @@
+# RUN: llvm-snippy %s -model-plugin=None -verify-mi |& FileCheck %s
+
+options:
+  mtriple: riscv64
+  dump-mf: on
+  mattr: "+c"
+  num-instrs: 10000
+  verify-gen-histogram: on
+  histogram-must-succeed: on
+
+scheduling:
+  enabled: on
+  max-region-size: 250
+
+include:
+  - Inputs/sections.yaml
+
+histogram-patterns:
+  - LdSd: "AND * (LD ^ 10) * SUB * (SD ^ 5)"
+  - C_LdSd: "(C_LW ^ 5) * C_LD | (C_SW ^ 3) * C_SD"
+
+histogram:
+  - [pattern: LdSd, 11]
+  - [pattern: C_LdSd, 11]
+  - [LB, 11]
+  - [LBU, 11]
+  - [LH, 11]
+  - [LHU, 11]
+  - [LW, 11]
+  - [LWU, 11]
+  - [SB, 16]
+  - [SH, 16]
+  - [PseudoNOP, 5]
+
+# CHECK-DAG: LB
+# CHECK-DAG: LBU
+# CHECK-DAG: LH
+# CHECK-DAG: LHU
+# CHECK-DAG: LW
+# CHECK-DAG: SB
+# CHECK-DAG: SH
+# CHECK-DAG: PseudoNOP
+
+# COM: Chekc LdSd pattern
+# CHECK: AND
+# CHECK-NEXT: LD
+# CHECK-NEXT: LD
+# CHECK-NEXT: LD
+# CHECK-NEXT: LD
+# CHECK-NEXT: LD
+# CHECK-NEXT: LD
+# CHECK-NEXT: LD
+# CHECK-NEXT: LD
+# CHECK-NEXT: LD
+# CHECK-NEXT: LD
+# CHECK-NEXT: SUB
+# CHECK-NEXT: SD
+# CHECK-NEXT: SD
+# CHECK-NEXT: SD
+# CHECK-NEXT: SD
+# CHECK-NEXT: SD
+
+# COM: Chekc LdSd pattern
+# CHECK: AND
+# CHECK-NEXT: LD
+# CHECK-NEXT: LD
+# CHECK-NEXT: LD
+# CHECK-NEXT: LD
+# CHECK-NEXT: LD
+# CHECK-NEXT: LD
+# CHECK-NEXT: LD
+# CHECK-NEXT: LD
+# CHECK-NEXT: LD
+# CHECK-NEXT: LD
+# CHECK-NEXT: SUB
+# CHECK-NEXT: SD
+# CHECK-NEXT: SD
+# CHECK-NEXT: SD
+# CHECK-NEXT: SD
+# CHECK-NEXT: SD
+
+# COM: Chekc C_LdSd pattern
+# CHECK: C_LW
+# CHECK-NEXT: C_LW
+# CHECK-NEXT: C_LW
+# CHECK-NEXT: C_LW
+# CHECK-NEXT: C_LW
+# CHECK-NEXT: C_LD
+
+# COM: Chekc C_LdSd pattern
+# CHECK: C_SW
+# CHECK-NEXT: C_SW
+# CHECK-NEXT: C_SW
+# CHECK-NEXT: C_SD
+
+# COM: Chekc C_LdSd pattern
+# CHECK: C_LW
+# CHECK-NEXT: C_LW
+# CHECK-NEXT: C_LW
+# CHECK-NEXT: C_LW
+# CHECK-NEXT: C_LW
+# CHECK-NEXT: C_LD
+
+# COM: Chekc C_LdSd pattern
+# CHECK: C_SW
+# CHECK-NEXT: C_SW
+# CHECK-NEXT: C_SW
+# CHECK-NEXT: C_SD

--- a/llvm/test/tools/llvm-snippy/random-scheduling-barriers.yaml
+++ b/llvm/test/tools/llvm-snippy/random-scheduling-barriers.yaml
@@ -1,0 +1,62 @@
+# REQUIRES: asserts 
+# RUN: llvm-snippy %s \
+# RUN:    -mtriple=riscv64 -model-plugin=None \
+# RUN:     -num-instrs=10000 -init-regs-in-elf -debug-only=snippy-riscv \
+# RUN:     -initial-regs=%S/initialization/Inputs/initial_state_rv64i.yaml \
+# RUN:     -random-scheduling \
+# RUN:  |& FileCheck %s 
+
+options:
+  mattr: +zifencei
+sections:
+    - name:      0
+      VMA:       0x10000
+      SIZE:      0x40000
+      LMA:       0x10000
+      ACCESS:    r
+    - name:      1
+      VMA:       0x100000
+      SIZE:      0x100000
+      LMA:       0x100000
+      ACCESS:    rx
+    - name:      2
+      VMA:       0x210000
+      SIZE:      0x100000
+      LMA:       0x210000
+      ACCESS:    rw
+
+histogram:
+  # branches
+  - [BEQ, 3.7]
+  - [BGE, 3.7]
+  - [BGEU, 3.7]
+  - [BLT, 3.7]
+  - [BLTU, 3.7]
+  - [BNE, 3.7]
+  - [ECALL, 10.0]
+  - [WFI, 10.0]
+  - [FENCE, 10.0]
+  - [FENCE_I, 10.0]
+  - [SFENCE_VMA, 10.0]
+  - [UNIMP, 10.0]
+  - [AUIPC, 10.0]
+  - [SW, 1.0]
+  - [ADD, 1.0]
+  - [XOR, 1.0]
+  - [AND, 1.0]
+  - [SUB, 1.0]
+branches:
+  number-of-loop-iterations:
+    min: 1
+    max: 2
+  max-depth:
+    if: 3
+    loop: 3
+
+# CHECK-DAG: Unsupported scheduling instruction : {{((\$x([0-9]+)))}} = AUIPC
+# CHECK-DAG: Unsupported scheduling instruction : ECALL
+# CHECK-DAG: Unsupported scheduling instruction : WFI
+# CHECK-DAG: Unsupported scheduling instruction : FENCE
+# CHECK-DAG: Unsupported scheduling instruction : FENCE_I
+# CHECK-DAG: Unsupported scheduling instruction : SFENCE_VMA
+# CHECK-DAG: Unsupported scheduling instruction : UNIMP

--- a/llvm/test/tools/llvm-snippy/random-scheduling-burst.yaml
+++ b/llvm/test/tools/llvm-snippy/random-scheduling-burst.yaml
@@ -1,0 +1,103 @@
+# RUN: llvm-snippy %s | FileCheck %s
+
+options:
+  mtriple: riscv64
+  mattr: "+m,+v"
+  num-instrs: 10000
+  dump-mf: on
+  verify-gen-histogram: on
+  histogram-must-succeed: on
+
+include:
+  - Inputs/sections.yaml
+
+scheduling:
+  enabled: on
+
+burst:
+  mode: custom
+  min-size: 5
+  max-size: 5
+  groupings:
+    - [LD]
+    - [SD]
+    - [LW]
+    - [SW]
+    - [VLE8_V]
+    - [VADD_VX]
+    - [VLSEG2E32_V]
+    - [VL2RE8_V]
+    - [VS2R_V]
+
+histogram:
+    - [LD, 1.0]
+    - [SD, 1.0]
+    - [LW, 1.0]
+    - [SW, 1.0]
+    - [VSETVL, 0.5]
+    - [VLE8_V, 1.0]
+    - [VADD_VX, 1.0]
+    - [VLSEG2E32_V, 1.0]
+    - [VL2RE8_V, 1.0]
+    - [VS2R_V, 1.0]
+    - [MUL, 1.0]
+    - [DIV, 1.0]
+    - [SUB, 1.0]
+
+# CHECK-DAG: MUL
+# CHECK-DAG: DIV
+# CHECK-DAG: SUB
+
+# CHECK: LD
+# CHECK-NEXT: LD
+# CHECK-NEXT: LD
+# CHECK-NEXT: LD
+# CHECK-NEXT: LD
+
+# CHECK: SD
+# CHECK-NEXT: SD
+# CHECK-NEXT: SD
+# CHECK-NEXT: SD
+# CHECK-NEXT: SD
+
+# CHECK: LW
+# CHECK-NEXT: LW
+# CHECK-NEXT: LW
+# CHECK-NEXT: LW
+# CHECK-NEXT: LW
+
+# CHECK: SW
+# CHECK-NEXT: SW
+# CHECK-NEXT: SW
+# CHECK-NEXT: SW
+# CHECK-NEXT: SW
+
+# CHECK: VLE8_V
+# CHECK-NEXT: VLE8_V
+# CHECK-NEXT: VLE8_V
+# CHECK-NEXT: VLE8_V
+# CHECK-NEXT: VLE8_V
+
+# CHECK: VADD_V
+# CHECK-NEXT: VADD_V
+# CHECK-NEXT: VADD_V
+# CHECK-NEXT: VADD_V
+# CHECK-NEXT: VADD_V
+
+# CHECK: VLSEG2E32_V
+# CHECK-NEXT: VLSEG2E32_V
+# CHECK-NEXT: VLSEG2E32_V
+# CHECK-NEXT: VLSEG2E32_V
+# CHECK-NEXT: VLSEG2E32_V
+
+# CHECK: VL2RE8_V
+# CHECK-NEXT: VL2RE8_V
+# CHECK-NEXT: VL2RE8_V
+# CHECK-NEXT: VL2RE8_V
+# CHECK-NEXT: VL2RE8_V
+
+# CHECK: VS2R_V
+# CHECK-NEXT: VS2R_V
+# CHECK-NEXT: VS2R_V
+# CHECK-NEXT: VS2R_V
+# CHECK-NEXT: VS2R_V

--- a/llvm/test/tools/llvm-snippy/random-scheduling-calls.yaml
+++ b/llvm/test/tools/llvm-snippy/random-scheduling-calls.yaml
@@ -1,0 +1,31 @@
+# REQUIRES: asserts
+# RUN: llvm-snippy %S/Inputs/jal-layout.yaml %s \
+# RUN:    -mtriple=riscv64 -enable-static-stack=false \
+# RUN:    -num-instrs=10000 -mattr=+c \
+# RUN:    -initial-regs=%S/initialization/Inputs/initial_state_rv64i.yaml \
+# RUN:    -o %t_1
+
+# RUN: llvm-snippy %S/Inputs/jal-layout.yaml %s \
+# RUN:    -mtriple=riscv64 -enable-static-stack=false \
+# RUN:    -num-instrs=10000 -mattr=+c -debug-only=snippy-riscv \
+# RUN:    -initial-regs=%S/initialization/Inputs/initial_state_rv64i.yaml \
+# RUN:    -o %t_2 -random-scheduling \
+# RUN:  |& FileCheck %s
+
+# RUN: not diff -q %t_1.elf %t_2.elf
+call-graph:
+  entry-point: SnippyFunction
+  function-list:
+    - name: SnippyFunction
+      callees:
+        - fun1
+        - fun2
+    - name: fun1
+      callees:
+        - fun2
+    - name: fun2
+      callees:
+        - fun3
+    - name: fun3
+
+# CHECK: Currently unsupported scheduling instruction : ${{[a-z0-9]+}} = PseudoJALCall

--- a/llvm/test/tools/llvm-snippy/random-scheduling-floats.yaml
+++ b/llvm/test/tools/llvm-snippy/random-scheduling-floats.yaml
@@ -1,0 +1,81 @@
+# RUN: llvm-snippy %s \
+# RUN:    -mtriple=riscv64 \
+# RUN:    -num-instrs=10000 -init-regs-in-elf -o %t_1 \
+# RUN:    -mattr=+c,+f \
+# RUN:    -initial-regs=%S/initialization/Inputs/initial_state_rv64i.yaml
+
+# RUN: llvm-snippy %s \
+# RUN:    -mtriple=riscv64 \
+# RUN:    -num-instrs=10000 -init-regs-in-elf -o %t_2 \
+# RUN:    -mattr=+c,+f -random-scheduling \
+# RUN:    -initial-regs=%S/initialization/Inputs/initial_state_rv64i.yaml
+
+# RUN: not diff -q %t_1.elf %t_2.elf
+
+sections:
+    - name:      1
+      VMA:       0x100000
+      SIZE:      0x1000000
+      LMA:       0x100000
+      ACCESS:    rx
+    - name:      2
+      VMA:       0x1100000
+      SIZE:      0x100000
+      LMA:       0x1100000
+      ACCESS:    rw
+
+histogram:
+  # branches ~ every 30 instructions
+  - [BEQ, 3.7]
+  - [BGE, 3.7]
+  - [BGEU, 3.7]
+  - [BLT, 3.7]
+  - [BLTU, 3.7]
+  - [BNE, 3.7]
+  - [C_BEQZ, 3.7]
+  - [C_BNEZ, 3.7]
+  - [C_J, 3.7]
+  # Floats
+  - [FMADD_S, 1.0]
+  - [FMSUB_S, 1.0]
+  - [FNMSUB_S, 1.0]
+  - [FNMADD_S, 1.0]
+  - [FADD_S, 1.0]
+  - [FSUB_S, 1.0]
+  - [FMUL_S, 1.0]
+  - [FDIV_S, 1.0]
+  - [FSQRT_S, 1.0]
+  - [FSGNJ_S, 1.0]
+  - [FSGNJN_S, 1.0]
+  - [FSGNJX_S, 1.0]
+  - [FMIN_S, 1.0]
+  - [FMAX_S, 1.0]
+  - [FCVT_W_S, 1.0]
+  - [FCVT_WU_S, 1.0]
+  - [FMV_X_W, 1.0]
+  - [FEQ_S, 1.0]
+  - [FLT_S, 1.0]
+  - [FLE_S, 1.0]
+  - [FCLASS_S, 1.0]
+  - [FCVT_S_W, 1.0]
+  - [FCVT_S_WU, 1.0]
+  - [FMV_W_X, 1.0]
+  - [FCVT_L_S, 1.0]
+  - [FCVT_LU_S, 1.0]
+  - [FCVT_S_L, 1.0]
+  - [FCVT_S_LU, 1.0]
+  - [FLW, 1.0]
+  - [FSW, 1.0]  
+  - [SW, 5.0]
+  - [ADD, 5.0]
+  - [XOR, 5.0]
+  - [AND, 5.0]
+  - [SUB, 5.0]
+branches:
+  number-of-loop-iterations:
+    min: 1
+    max: 2
+  max-depth:
+    if: 3
+    loop: 3
+

--- a/llvm/test/tools/llvm-snippy/random-scheduling-init-regs-in-elf.yaml
+++ b/llvm/test/tools/llvm-snippy/random-scheduling-init-regs-in-elf.yaml
@@ -1,0 +1,40 @@
+# RUN: llvm-snippy %s -model-plugin=None -verify-mi -dump-mir=- | FileCheck %s
+
+# COM: Check that we tracks the liveness and 'verify-mi' finishes without errors.
+
+sections:
+- name: sect_rx_45a440000
+  PHDR: sect_rx_45a440000
+  VMA: 0x45a440000
+  SIZE: 0x2400000
+  LMA: 0x45a440000
+  ACCESS: rx
+- name: stack
+  PHDR: stack
+  VMA: 0x429f4c000
+  SIZE: 0x10000
+  LMA: 0x429f4c000
+  ACCESS: rw
+- name: somesect
+  VMA: 0x4692cd000
+  SIZE: 0x1000000
+  LMA: 0x4692cd000
+  ACCESS: rw
+histogram:
+- [ADDI, 1]
+options:
+  external-stack: 'True'
+  riscv-disable-misaligned-access: atomics-only
+  random-scheduling: 'True'
+  enable-phdrs-definition: 'True'
+  num-instrs: 50
+  last-instr: RET
+  mcpu: scr9
+  mtriple: riscv64
+  mattr: +zifencei,+xsccache
+  honor-target-abi: 'True'
+  mangle-exported-names: 'True'
+  init-regs-in-elf: 'True'
+  entry-point: test_0
+
+# CHECK: tracksRegLiveness: true

--- a/llvm/test/tools/llvm-snippy/random-scheduling-option-and-config.yaml
+++ b/llvm/test/tools/llvm-snippy/random-scheduling-option-and-config.yaml
@@ -1,0 +1,9 @@
+# RUN: not llvm-snippy %s -model-plugin None -random-scheduling |& FileCheck %s
+# CHECK: random-scheduling-option-and-config.yaml:5:3: error: 'random-scheduling' has been specified both as an option and as a configuration field 'enabled'
+
+scheduling:
+  enabled: true
+options:
+  num-instrs: 10
+  mtriple: riscv64
+  mcpu: generic-rv64

--- a/llvm/test/tools/llvm-snippy/random-scheduling.yaml
+++ b/llvm/test/tools/llvm-snippy/random-scheduling.yaml
@@ -1,0 +1,218 @@
+# RUN: llvm-snippy %s \
+# RUN:    -o %t_1 \
+# RUN:    -initial-regs=%S/initialization/Inputs/initial_state_rv64i.yaml
+
+# RUN: llvm-snippy %s \
+# RUN:    -o %t_2 \
+# RUN:    -random-scheduling \
+# RUN:    -initial-regs=%S/initialization/Inputs/initial_state_rv64i.yaml
+
+# RUN: llvm-snippy %s \
+# RUN:    %S/Inputs/random-scheduling/basic.yaml \
+# RUN:    -o %t_3 \
+# RUN:    -initial-regs=%S/initialization/Inputs/initial_state_rv64i.yaml
+
+# RUN: not diff -q %t_1.elf %t_2.elf
+# RUN: not diff -q %t_1.elf %t_3.elf
+
+options:
+  num-instrs: 10000
+  mtriple: riscv64
+  mattr: -f,+a,+c,+m
+  init-regs-in-elf: true
+sections:
+  - name: 1
+    VMA: 0x100000
+    SIZE: 0x1000000
+    LMA: 0x100000
+    ACCESS: rx
+  - name: 2
+    VMA: 0x1100000
+    SIZE: 0x100000
+    LMA: 0x1100000
+    ACCESS: rw
+branches:
+  number-of-loop-iterations:
+    min: 1
+    max: 2
+  max-depth:
+    if: 3
+    loop: 3
+histogram:
+  # branches
+  - [BEQ, 3.7]
+  - [BGE, 3.7]
+  - [BGEU, 3.7]
+  - [BLT, 3.7]
+  - [BLTU, 3.7]
+  - [BNE, 3.7]
+  - [C_BEQZ, 3.7]
+  - [C_BNEZ, 3.7]
+  - [C_J, 3.7]
+  # loads/stores ~ 2/3 instruction
+  - [C_LD, 29]
+  - [C_LW, 29]
+  - [C_SD, 29]
+  - [C_SW, 29]
+  - [LB, 29]
+  - [LBU, 29]
+  - [LD, 29]
+  - [LH, 29]
+  - [LHU, 29]
+  - [LR_D, 29]
+  - [LR_D_AQ, 29]
+  - [LR_W, 29]
+  - [LR_W_AQ, 29]
+  - [LW, 29]
+  - [LWU, 29]
+  - [SB, 29]
+  - [SC_D, 29]
+  - [SC_D_RL, 29]
+  - [SC_W, 29]
+  - [SC_W_RL, 29]
+  - [SD, 29]
+  - [SH, 29]
+  - [SW, 29]
+  # other ~1/3 instructions, atomics 10 time less
+  - [ADD, 4.26]
+  - [ADDI, 4.26]
+  - [ADDIW, 4.26]
+  - [ADDW, 4.26]
+  - [AMOADD_D, 0.43]
+  - [AMOADD_D_AQ, 0.43]
+  - [AMOADD_D_AQ_RL, 0.43]
+  - [AMOADD_D_RL, 0.43]
+  - [AMOADD_W, 0.43]
+  - [AMOADD_W_AQ, 0.43]
+  - [AMOADD_W_AQ_RL, 0.43]
+  - [AMOADD_W_RL, 0.43]
+  - [AMOAND_D, 0.43]
+  - [AMOAND_D_AQ, 0.43]
+  - [AMOAND_D_AQ_RL, 0.43]
+  - [AMOAND_D_RL, 0.43]
+  - [AMOAND_W, 0.43]
+  - [AMOAND_W_AQ, 0.43]
+  - [AMOAND_W_AQ_RL, 0.43]
+  - [AMOAND_W_RL, 0.43]
+  - [AMOMAXU_D, 0.43]
+  - [AMOMAXU_D_AQ, 0.43]
+  - [AMOMAXU_D_AQ_RL, 0.43]
+  - [AMOMAXU_D_RL, 0.43]
+  - [AMOMAXU_W, 0.43]
+  - [AMOMAXU_W_AQ, 0.43]
+  - [AMOMAXU_W_AQ_RL, 0.43]
+  - [AMOMAXU_W_RL, 0.43]
+  - [AMOMAX_D, 0.43]
+  - [AMOMAX_D_AQ, 0.43]
+  - [AMOMAX_D_AQ_RL, 0.43]
+  - [AMOMAX_D_RL, 0.43]
+  - [AMOMAX_W, 0.43]
+  - [AMOMAX_W_AQ, 0.43]
+  - [AMOMAX_W_AQ_RL, 0.43]
+  - [AMOMAX_W_RL, 0.43]
+  - [AMOMINU_D, 0.43]
+  - [AMOMINU_D_AQ, 0.43]
+  - [AMOMINU_D_AQ_RL, 0.43]
+  - [AMOMINU_D_RL, 0.43]
+  - [AMOMINU_W, 0.43]
+  - [AMOMINU_W_AQ, 0.43]
+  - [AMOMINU_W_AQ_RL, 0.43]
+  - [AMOMINU_W_RL, 0.43]
+  - [AMOMIN_D, 0.43]
+  - [AMOMIN_D_AQ, 0.43]
+  - [AMOMIN_D_AQ_RL, 0.43]
+  - [AMOMIN_D_RL, 0.43]
+  - [AMOMIN_W, 0.43]
+  - [AMOMIN_W_AQ, 0.43]
+  - [AMOMIN_W_AQ_RL, 0.43]
+  - [AMOMIN_W_RL, 0.43]
+  - [AMOOR_D, 0.43]
+  - [AMOOR_D_AQ, 0.43]
+  - [AMOOR_D_AQ_RL, 0.43]
+  - [AMOOR_D_RL, 0.43]
+  - [AMOOR_W, 0.43]
+  - [AMOOR_W_AQ, 0.43]
+  - [AMOOR_W_AQ_RL, 0.43]
+  - [AMOOR_W_RL, 0.43]
+  - [AMOSWAP_D, 0.43]
+  - [AMOSWAP_D_AQ, 0.43]
+  - [AMOSWAP_D_AQ_RL, 0.43]
+  - [AMOSWAP_D_RL, 0.43]
+  - [AMOSWAP_W, 0.43]
+  - [AMOSWAP_W_AQ, 0.43]
+  - [AMOSWAP_W_AQ_RL, 0.43]
+  - [AMOSWAP_W_RL, 0.43]
+  - [AMOXOR_D, 0.43]
+  - [AMOXOR_D_AQ, 0.43]
+  - [AMOXOR_D_AQ_RL, 0.43]
+  - [AMOXOR_D_RL, 0.43]
+  - [AMOXOR_W, 0.43]
+  - [AMOXOR_W_AQ, 0.43]
+  - [AMOXOR_W_AQ_RL, 0.43]
+  - [AMOXOR_W_RL, 0.43]
+  - [AND, 4.26]
+  - [ANDI, 4.26]
+  - [C_ADD, 4.26]
+  - [C_ADDI, 4.26]
+  - [C_ADDIW, 4.26]
+  - [C_ADDI_HINT_IMM_ZERO, 4.26]
+  - [C_NOP, 4.26]
+  - [C_ADDW, 4.26]
+  - [C_ADD_HINT, 4.26]
+  - [C_AND, 4.26]
+  - [C_ANDI, 4.26]
+  - [C_LI, 4.26]
+  - [C_LI_HINT, 4.26]
+  - [C_LUI, 4.26]
+  - [C_LUI_HINT, 4.26]
+  - [C_MV, 4.26]
+  - [C_MV_HINT, 4.26]
+  - [C_NOP, 4.26]
+  - [C_NOP_HINT, 4.26]
+  - [C_OR, 4.26]
+  - [C_SLLI, 4.26]
+  - [C_SLLI64_HINT, 4.26]
+  - [C_SLLI_HINT, 4.26]
+  - [C_SRAI, 4.26]
+  - [C_SRAI64_HINT, 4.26]
+  - [C_SRLI, 4.26]
+  - [C_SRLI64_HINT, 4.26]
+  - [C_SUB, 4.26]
+  - [C_SUBW, 4.26]
+  - [C_XOR, 4.26]
+  - [DIV, 4.26]
+  - [DIVU, 4.26]
+  - [DIVUW, 4.26]
+  - [DIVW, 4.26]
+  - [LUI, 4.26]
+  - [MUL, 4.26]
+  - [MULH, 4.26]
+  - [MULHSU, 4.26]
+  - [MULHU, 4.26]
+  - [MULW, 4.26]
+  - [OR, 4.26]
+  - [ORI, 4.26]
+  - [REM, 4.26]
+  - [REMU, 4.26]
+  - [REMUW, 4.26]
+  - [REMW, 4.26]
+  - [SLL, 4.26]
+  - [SLLI, 4.26]
+  - [SLLIW, 4.26]
+  - [SLLW, 4.26]
+  - [SLT, 4.26]
+  - [SLTI, 4.26]
+  - [SLTIU, 4.26]
+  - [SLTU, 4.26]
+  - [SRA, 4.26]
+  - [SRAI, 4.26]
+  - [SRAIW, 4.26]
+  - [SRAW, 4.26]
+  - [SRL, 4.26]
+  - [SRLI, 4.26]
+  - [SRLIW, 4.26]
+  - [SRLW, 4.26]
+  - [SUB, 4.26]
+  - [SUBW, 4.26]
+  - [XOR, 4.26]
+  - [XORI, 4.26]

--- a/llvm/tools/llvm-snippy/docs/index.rst
+++ b/llvm/tools/llvm-snippy/docs/index.rst
@@ -1887,6 +1887,8 @@ Advanced configuration includes keys for:
 -  `Basic block layout <#basic-block-layout>`__
 
 
+-  `Random scheduling pass <#random-scheduling>`__
+
 -  `Register Reservation Config`_
 
 .. _register-reservation:
@@ -2375,6 +2377,122 @@ The generated snippet includes a part of the trace:
 
 where ``jalr`` is ``fun3`` |nbsp| -- |nbsp| a weak symbol in the snippet (a stub for
 the model) to which you want to link the user function.
+
+
+.. _`_random_scheduling`:
+
+Random Scheduling
+-----------------
+
+Use the ``random-scheduling`` feature to apply a random scheduling pass
+for the generated code. It reorders instructions according to a topology
+sort of data dependency graph for each basic block of each function.
+
+To enable ``random-scheduling``, use one of the following approaches:
+
+-  Using the ``scheduling`` top-level key (preferred):
+
+   ::
+
+      scheduling:
+        enabled: true
+
+-  Using the ``random-scheduling`` key in ``options`` (outdated, but
+   still supported):
+
+   ::
+
+      options:
+        random-scheduling: true
+
+-  Via snippy command line:
+
+   ::
+
+      -random-scheduling
+
+Random scheduling does not change the behaviour of the program. However,
+it might be ineffective for large basic blocks, as they force it to run
+for a long time. To control this behavior, you can `configure the
+maximum size of scheduling
+regions <#configuring-max-size-of-scheduling-region>`__.
+
+Random scheduling also does not affect barrier instructions |nbsp| -- |nbsp| these are
+instructions that have various side effects, for example:
+
+-  ``EBREAK`` and ``ECALL``
+
+-  ``VSET*``
+
+-  ``UNIMP``
+
+-  ``WFI``
+
+-  Fence instructions (``FENCE``, ``FENCE_I``)
+
+-  ``SFENCE_VMA``
+
+.. _`_limitations_2`:
+
+Limitations
+~~~~~~~~~~~
+
+The following is a list of instructions snippy does not currently
+schedule:
+
+-  RVV instructions
+
+-  Floating point instructions
+
+-  Branches
+
+-  EBREAK and ECALL
+
+-  The last instruction in the last basic block of ``EntryFunction``
+
+However, if you have such instructions in the basic block, the pass:
+
+1. Splits the block into regions that only consist of the supported
+   instructions.
+
+2. Schedules all these regions.
+
+Configuring Max Size of Scheduling Region
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Specify the maximum number of instructions for random scheduling using
+the ``max-region-size`` feature. It changes the default value ``131072``
+to a certain reasonable number, this way controlling the size of the
+scheduling region.
+
+.. note::
+
+   The reasonable maximum number of instructions for this option depends
+   on the configuration, but it must not be too small, as this will
+   result in long runtimes.
+
+To use the ``max-region-size`` feature, ``random-scheduling`` must be
+explicitly enabled in your configuration, as described above.
+
+-  If you used the ``scheduling`` key, add ``max-region-size`` to it:
+
+   .. code:: yaml
+
+      scheduling:
+        enabled: true
+        max-region-size: 20000
+
+-  If you used the ``options`` key, add the ``scheduling`` key with
+   ``max-region-size``:
+
+   ::
+
+      options:
+        random-scheduling: true
+      scheduling:
+        max-region-size: 20000
+
+.. _`_options`:
 
 Options
 =======

--- a/llvm/tools/llvm-snippy/include/snippy/Config/Config.h
+++ b/llvm/tools/llvm-snippy/include/snippy/Config/Config.h
@@ -26,6 +26,8 @@
 #include "snippy/Support/YAMLUtils.h"
 #include "snippy/Target/TargetConfigIface.h"
 
+#include "snippy/Config/Scheduling.h"
+
 #include "llvm/ADT/SmallSet.h"
 
 #include <unordered_map>
@@ -257,6 +259,7 @@ public:
   std::variant<CallGraphLayout, FunctionDescs> CGLayout;
 
   std::optional<CodeLayoutConfig> CodeLayout;
+  SchedulingSettings Scheduling;
   TraceConvertOptions TFOpts;
   PassConfig(const ProgramConfig &ProgramCfg) : ProgramCfg(&ProgramCfg) {}
 

--- a/llvm/tools/llvm-snippy/include/snippy/CreatePasses.h
+++ b/llvm/tools/llvm-snippy/include/snippy/CreatePasses.h
@@ -76,6 +76,7 @@ snippy::ActiveImmutablePassInterface *createInstructionGeneratorPass();
 
 MachineFunctionPass *createLoopAlignmentPass();
 
+MachineFunctionPass *createRandomSchedulingPass(unsigned MaxRegionSize);
 
 MachineFunctionPass *createInstructionsPostProcessPass();
 

--- a/llvm/tools/llvm-snippy/include/snippy/Target/Target.h
+++ b/llvm/tools/llvm-snippy/include/snippy/Target/Target.h
@@ -454,6 +454,8 @@ public:
 
   virtual bool branchNeedsVerification(const MachineInstr &Branch) const = 0;
 
+  virtual bool mayBeScheduled(const MachineInstr &MI) const = 0;
+
   virtual MachineBasicBlock *
   getBranchDestination(const MachineInstr &Branch) const = 0;
 

--- a/llvm/tools/llvm-snippy/lib/CMakeLists.txt
+++ b/llvm/tools/llvm-snippy/lib/CMakeLists.txt
@@ -53,6 +53,7 @@ set(LLVMSnippySources
   PassManagerWrapper.cpp
   PrintMachineInstrsPass.cpp
   PrologueEpilogueInsertionPass.cpp
+  RandomSchedulingPass.cpp
   RegsInitInsertionPass.cpp
   ReserveRegsPass.cpp
   MemoryInitializerPass.cpp

--- a/llvm/tools/llvm-snippy/lib/Config/CMakeLists.txt
+++ b/llvm/tools/llvm-snippy/lib/Config/CMakeLists.txt
@@ -13,6 +13,7 @@ set(LLVMSnippyConfigSources
     CallGraphLayout.cpp
     ImmediateHistogram.cpp
     OperandsReinitialization.cpp
+    Scheduling.cpp
     Valuegram.cpp
     Selfcheck.cpp
     )

--- a/llvm/tools/llvm-snippy/lib/Config/Config.cpp
+++ b/llvm/tools/llvm-snippy/lib/Config/Config.cpp
@@ -1358,6 +1358,7 @@ void yaml::MappingTraits<Config>::mapping(yaml::IO &IO, Config &Info) {
   Info.ProgramCfg.TargetConfig->mapConfig(IO);
   IO.mapOptional("fpu-config", Info.CommonPolicyCfg->FPUConfig);
   IO.mapOptional("code-layout", Info.PassCfg.CodeLayout);
+  IO.mapOptional("scheduling", Info.PassCfg.Scheduling);
   IO.mapOptional("operands-reinitialization",
                  Info.DefFlowConfig.OperandsReinitialization);
   MappingNormalization<RegisterAccessNormalization, RegisterAccessConfig>

--- a/llvm/tools/llvm-snippy/lib/FlowGenerator.cpp
+++ b/llvm/tools/llvm-snippy/lib/FlowGenerator.cpp
@@ -329,6 +329,9 @@ GeneratorResult FlowGenerator::generate(LLVMState &State,
         if (VerifyConsecutiveLoops)
           PM.add(createConsecutiveLoopsVerifierPass());
 
+        if (auto Sched = GenCtx.getConfig().PassCfg.Scheduling;
+            Sched.isEnabled())
+          PM.add(createRandomSchedulingPass(Sched.MaxRegionSize));
         // Update liveness information
         PM.add(createTrackLivenessPass());
         if (DebugCfg.DumpMF.value())

--- a/llvm/tools/llvm-snippy/lib/InitializePasses.cpp
+++ b/llvm/tools/llvm-snippy/lib/InitializePasses.cpp
@@ -33,6 +33,7 @@ void llvm::snippy::initializeSnippyPasses(PassRegistry &Registry) {
   initializeRegsInitInsertionPass(Registry);
   initializePrologueEpilogueInsertionPass(Registry);
   initializePrintMachineInstrsPass(Registry);
+  initializeRandomSchedulingPass(Registry);
   initializeTrackLivenessPass(Registry);
   initializeInstructionsPostProcessPass(Registry);
   initializeBranchRelaxatorPass(Registry);

--- a/llvm/tools/llvm-snippy/lib/InitializePasses.h
+++ b/llvm/tools/llvm-snippy/lib/InitializePasses.h
@@ -32,6 +32,7 @@ void initializeInstructionGeneratorPass(PassRegistry &);
 void initializeRegsInitInsertionPass(PassRegistry &);
 void initializePrologueEpilogueInsertionPass(PassRegistry &);
 void initializePrintMachineInstrsPass(PassRegistry &);
+void initializeRandomSchedulingPass(PassRegistry &);
 void initializeTrackLivenessPass(PassRegistry &);
 void initializeInstructionsPostProcessPass(PassRegistry &);
 void initializePostGenVerifierPass(PassRegistry &);

--- a/llvm/tools/llvm-snippy/lib/RandomSchedulingPass.cpp
+++ b/llvm/tools/llvm-snippy/lib/RandomSchedulingPass.cpp
@@ -1,0 +1,357 @@
+//===-- RandomSchedulingPass.cpp    ----------------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+///
+/// RandomScheduling is post-processing pass for InstructionGenerator pass. This
+/// pass permutes instructions within each MachineBasicBlock of MachineFunction
+/// according to a random topological sort on its DDG
+///
+//===----------------------------------------------------------------------===//
+
+#include "InitializePasses.h"
+#include "snippy/CreatePasses.h"
+#include "snippy/Generator/GeneratorContextPass.h"
+#include "snippy/Support/Options.h"
+#include "snippy/Support/RandUtil.h"
+#include "snippy/Target/Target.h"
+
+#include "llvm/ADT/STLExtras.h"
+#include "llvm/Analysis/AliasAnalysis.h"
+#include "llvm/Analysis/TargetLibraryInfo.h"
+#include "llvm/CodeGen/MachineFunction.h"
+#include "llvm/CodeGen/MachineFunctionPass.h"
+#include "llvm/CodeGen/MachineLoopInfo.h"
+#include "llvm/CodeGen/ScheduleDAGInstrs.h"
+#include "llvm/Support/Debug.h"
+#include "llvm/Support/GraphWriter.h"
+
+namespace llvm {
+template <>
+struct DOTGraphTraits<ScheduleDAG *> : public DefaultDOTGraphTraits {
+
+  DOTGraphTraits(bool isSimple = false) : DefaultDOTGraphTraits(isSimple) {}
+
+  static std::string getGraphName(const ScheduleDAG *G) {
+    return std::string(G->MF.getName());
+  }
+
+  static bool renderGraphFromBottomUp() { return true; }
+
+  static bool isNodeHidden(const SUnit *Node, const ScheduleDAG *G) {
+    return (Node->NumPreds > 10 || Node->NumSuccs > 10);
+  }
+
+  static std::string getNodeIdentifierLabel(const SUnit *Node,
+                                            const ScheduleDAG *Graph) {
+    std::string R;
+    raw_string_ostream OS(R);
+    OS << static_cast<const void *>(Node);
+    return R;
+  }
+
+  static std::string getEdgeAttributes(const SUnit *Node, SUnitIterator EI,
+                                       const ScheduleDAG *Graph) {
+    if (EI.isArtificialDep())
+      return "color=cyan,style=dashed";
+    if (EI.isCtrlDep())
+      return "color=blue,style=dashed";
+    return "";
+  }
+
+  std::string getNodeLabel(const SUnit *SU, const ScheduleDAG *Graph);
+  static std::string getNodeAttributes(const SUnit *N,
+                                       const ScheduleDAG *Graph) {
+    return "shape=Mrecord";
+  }
+
+  static void addCustomGraphFeatures(ScheduleDAG *G,
+                                     GraphWriter<ScheduleDAG *> &GW) {
+    return G->addCustomGraphFeatures(GW);
+  }
+};
+} // namespace llvm
+
+namespace llvm::snippy {
+
+extern cl::OptionCategory Options;
+
+static snippy::opt<std::string>
+    DumpSchedDAGName("dump-sched-dag",
+                     cl::desc("specify a title for dot-dump scheduled basick "
+                              "block (under LLVM_DEBUG)"),
+                     cl::value_desc("imagetitle"), cl::Hidden, cl::cat(Options),
+                     cl::init("DAG"));
+namespace {
+
+#define DEBUG_TYPE "snippy-random-scheduling"
+#define PASS_DESC "Snippy-random-scheduling"
+
+class RandomScheduling final : public MachineFunctionPass {
+  // We use ScheduleDAGInstrs routine to build DDG.
+  // Then we implement the algorithm of getting random topology sorting:
+  // Algorithm description:
+  // Let's look at the following graph:
+  //                      i1       i7
+  //                     /  \      |
+  //                   i2    i3    i8
+  //                  / | \
+  //                i4  i5 \
+  //                        i6
+  // SUnits : [i1, i2, i3, i4, i5, i6, i7, i8]
+  // We want to collect a random topological sequence RandomTopologicalSUnitsSeq
+  // : [] First of all, we need to pick out all SUnits without any predecessors:
+  // ZeroPredUnits : [i1, i7]
+  // Then we choose random one SUnit from ZeroPredUnits. Suppose we choose i1.
+  // After this, we need to remove edges between i1 and {i2, i3}
+  // Then, i2 and i3 nodes have no predecessors, so we can add them into
+  // ZeroPredUnits and remove i1 from the candiadates ZeroPredUnits : [i7, i2,
+  // i3] Then, put i1 to RandomTopologicalSUnitsSeq : [i1] Next itteration will
+  // happen with the transformed graph:
+  //                   i2    i3    i7
+  //                  / | \        |
+  //                i4  i5 \       i8
+  //                        i6
+  // Repeat all actions...
+  // The algorithm stops when ZeroPredUnits becomes empty
+  // In this case possible random topological sequence:
+  // RandomTopologicalSUnitsSeq: [i1, i3, i7, i2, i5, i8, i4, i6]
+  class SnippyRandomScheduler : public ScheduleDAGInstrs {
+    using ItType = MachineBasicBlock::iterator;
+    // Vector of regions to schedule (with Begin / End iterators)
+    using RegionsToSchedTy = SmallVector<std::pair<ItType, ItType>>;
+
+    TargetLibraryInfoImpl TLIImpl;
+    TargetLibraryInfo TLI;
+    AAResults AA;
+    const SnippyProgramContext &ProgCtx;
+    unsigned TheMaxRegionSize;
+
+    std::vector<std::reference_wrapper<SUnit>> getRandomTopologicalSort() {
+      std::vector<std::reference_wrapper<SUnit>> RandomTopologicalSUnitsSeq;
+      std::vector<std::reference_wrapper<SUnit>> ZeroPredUnits;
+
+      std::copy_if(SUnits.begin(), SUnits.end(),
+                   std::back_inserter(ZeroPredUnits),
+                   [](const auto &SU) { return SU.Preds.empty(); });
+
+      UniformIntDistribution<unsigned> Dist;
+      auto &Engine = RandEngine::engine();
+      while (!ZeroPredUnits.empty()) {
+        // Choose a random one from ZeroPredUnits
+        auto Idx = Dist(Engine) % ZeroPredUnits.size();
+        auto RandomSUnitFromCandidates = ZeroPredUnits[Idx];
+        // Delete current SUnit form preds of all its succs
+        for (auto &&Succ : RandomSUnitFromCandidates.get().Succs) {
+          auto *SuccSUnit = Succ.getSUnit();
+          assert(SuccSUnit);
+
+          auto It =
+              std::find_if(SuccSUnit->Preds.begin(), SuccSUnit->Preds.end(),
+                           [RandomSUnitFromCandidates](const auto &SuccPred) {
+                             return SuccPred.getSUnit()->getInstr() ==
+                                    RandomSUnitFromCandidates.get().getInstr();
+                           });
+          assert(It != SuccSUnit->Preds.end());
+          SuccSUnit->Preds.erase(It);
+
+          // If the succ's SUnit has no preds any more, we can add it to
+          // ZeroPredUnits
+          if (SuccSUnit->Preds.empty())
+            ZeroPredUnits.push_back(*SuccSUnit);
+        }
+        // Added handled SUnit to the topological sequence
+        RandomTopologicalSUnitsSeq.push_back(RandomSUnitFromCandidates);
+        // As soon as we handle SUnit, we need to remove it from candidates
+        std::swap(ZeroPredUnits[Idx], ZeroPredUnits.back());
+        ZeroPredUnits.pop_back();
+      }
+
+      return RandomTopologicalSUnitsSeq;
+    }
+
+    void reorderBasicBlock(MachineBasicBlock &MBB,
+                           const std::vector<std::reference_wrapper<SUnit>>
+                               &RandomTopologicalSUnitsSeq) const {
+      for (auto &&Unit : RandomTopologicalSUnitsSeq) {
+        auto It = Unit.get().getInstr()->getIterator();
+        assert(It != MBB.end());
+        MBB.splice(end(), &MBB, It);
+      }
+    }
+
+    auto getRegionsForMBBScheduling(MachineBasicBlock &MBB) {
+      // Instructions marked with only Bundle metadata are not subject to
+      // scheduling. However, such bundle groups are often preceded by support
+      // instruction groups (e.g., for address formation). These support groups
+      // can be scheduled within their own boundaries. Therefore, we schedule
+      // them separately
+      auto IsSupportBundleInstr = [](auto &&Instr) {
+        return checkMetadata(Instr, SnippyMetadata::Bundle) &&
+               checkMetadata(Instr, SnippyMetadata::Support);
+      };
+      RegionsToSchedTy SupportRegionsToSched;
+      for (auto Begin = MBB.begin(), End = MBB.end(); Begin != End;) {
+        auto SupportRangeStart = Begin;
+        Begin = std::find_if_not(Begin, End, IsSupportBundleInstr);
+        if (SupportRangeStart != Begin)
+          SupportRegionsToSched.emplace_back(SupportRangeStart, Begin);
+        else
+          ++Begin;
+      }
+      const auto &SnippyTgt = ProgCtx.getLLVMState().getSnippyTarget();
+      RegionsToSchedTy Regions;
+      for (auto &&[SuppBegin, SuppEnd] : SupportRegionsToSched)
+        fillSchedulingRegions(SuppBegin, SuppEnd, SnippyTgt, Regions);
+      // Schedule all the remaining instructions, no longer taking into account
+      // the support instructions for the bundles
+      fillSchedulingRegions(MBB.begin(), MBB.end(), SnippyTgt, Regions);
+      return Regions;
+    }
+
+    void fillSchedulingRegions(ItType BeginIt, ItType EndIt,
+                               const SnippyTarget &SnippyTgt,
+                               RegionsToSchedTy &Regions) const {
+      static constexpr auto MinimalRegionRange = 3u;
+
+      auto MayBeSched = [&SnippyTgt](const auto &MI) {
+        return SnippyTgt.mayBeScheduled(MI);
+      };
+
+      // This is basically chunking by a predicate with an upper limit on the
+      // chunk size.
+      auto FindIfWithUpperSizeLimit = [&](auto Begin, auto &&Pred) {
+        size_t Count = 0;
+        for (Count = 0;
+             Begin != EndIt && Count < TheMaxRegionSize && !Pred(*Begin);
+             ++Count, ++Begin) {
+        }
+        return std::pair{Begin, Count};
+      };
+
+      while ((BeginIt = FindIfWithUpperSizeLimit(BeginIt, MayBeSched).first) !=
+             EndIt) {
+        auto [CurEnd, Count] =
+            FindIfWithUpperSizeLimit(BeginIt, std::not_fn(MayBeSched));
+        if (Count > MinimalRegionRange)
+          Regions.emplace_back(BeginIt, CurEnd);
+        BeginIt = CurEnd;
+      }
+    }
+
+    template <typename ItType>
+    void buildDDGForRegion(ItType RegStart, ItType RegEnd,
+                           MachineBasicBlock &MBB) {
+      auto Begin = RegStart;
+      assert(Begin != RegEnd);
+      auto End = RegEnd;
+
+      enterRegion(&MBB, Begin, End, std::distance(Begin, End));
+      buildSchedGraph(&AA);
+    }
+
+    void buildDDGForMBB(MachineBasicBlock &MBB) {
+      startBlock(&MBB);
+      auto Begin = MBB.begin();
+      assert(Begin != MBB.end());
+      auto End = MBB.getFirstTerminator();
+      // Last instruction in a some basic block can be custom or interrupt one
+      if (End == MBB.end())
+        End = std::prev(MBB.end());
+      assert(End != MBB.end());
+
+      enterRegion(&MBB, Begin, End, std::distance(Begin, End));
+      buildSchedGraph(&AA);
+    }
+
+  public:
+    SnippyRandomScheduler(MachineFunction &MF, const MachineLoopInfo *MLI,
+                          const SnippyProgramContext &ProgCtx,
+                          unsigned MaxRegionSize)
+        : ScheduleDAGInstrs(MF, MLI, /* RemoveKillFlags */ false),
+          TLIImpl(ProgCtx.getLLVMState().getTargetMachine().getTargetTriple()),
+          TLI(TLIImpl), AA(TLI), ProgCtx(ProgCtx),
+          TheMaxRegionSize(MaxRegionSize) {}
+
+    void scheduleBasicBlock(MachineBasicBlock &MBB) {
+      auto Regions = getRegionsForMBBScheduling(MBB);
+      LLVM_DEBUG(buildDDGForMBB(MBB); dumpDotGraphToFile(
+                     cast<ScheduleDAG>(this),
+                     DumpSchedDAGName.getValue() + "-" + MBB.getFullName(),
+                     "ScedulingPass"););
+      // Required by buildSchedGraph method defined in ScheduleDAGInstrs
+      startBlock(&MBB);
+      for (auto &&Reg : Regions) {
+        buildDDGForRegion(Reg.first, Reg.second, MBB);
+        auto &&RandomTopologicalSUnitsSeq = getRandomTopologicalSort();
+        // Reorganization of BB after scheduling
+        [[maybe_unused]] auto InitBBSize = MBB.size();
+        reorderBasicBlock(MBB, RandomTopologicalSUnitsSeq);
+      }
+      LLVM_DEBUG(buildDDGForMBB(MBB);
+                 dumpDotGraphToFile(cast<ScheduleDAG>(this),
+                                    DumpSchedDAGName.getValue() + "-" +
+                                        MBB.getFullName() + "-scheduled",
+                                    "ScedulingPass"););
+    }
+
+    void schedule() override {
+      auto &RegInfo = MF.getRegInfo();
+      RegInfo.freezeReservedRegs();
+
+      for (auto &&MBB : MF)
+        scheduleBasicBlock(MBB);
+    }
+  };
+
+public:
+  static char ID;
+
+  RandomScheduling(unsigned MaxRegionSize)
+      : MachineFunctionPass(ID), TheMaxRegionSize(MaxRegionSize) {}
+
+  StringRef getPassName() const override { return PASS_DESC " Pass"; }
+
+  bool runOnMachineFunction(MachineFunction &MF) override {
+    auto &SGCtx = getAnalysis<GeneratorContextWrapper>().getContext();
+    auto &MLI = getAnalysis<MachineLoopInfoWrapperPass>().getLI();
+
+    MF.getProperties().set(MachineFunctionProperties::Property::TracksLiveness);
+
+    SnippyRandomScheduler Scheduler(MF, &MLI, SGCtx.getProgramContext(),
+                                    TheMaxRegionSize);
+    Scheduler.schedule();
+    return true;
+  }
+
+  void getAnalysisUsage(AnalysisUsage &AU) const override {
+    AU.addRequired<GeneratorContextWrapper>();
+    AU.addRequired<MachineLoopInfoWrapperPass>();
+    MachineFunctionPass::getAnalysisUsage(AU);
+  }
+
+private:
+  unsigned TheMaxRegionSize;
+};
+
+char RandomScheduling::ID = 0;
+
+} // namespace
+} // namespace llvm::snippy
+
+using llvm::callDefaultCtor;
+using llvm::PassInfo;
+using llvm::PassRegistry;
+using llvm::snippy::RandomScheduling;
+
+INITIALIZE_PASS_BEGIN(RandomScheduling, DEBUG_TYPE, PASS_DESC, false, false)
+INITIALIZE_PASS_DEPENDENCY(GeneratorContextWrapper)
+INITIALIZE_PASS_END(RandomScheduling, DEBUG_TYPE, PASS_DESC, false, false)
+namespace llvm {
+MachineFunctionPass *createRandomSchedulingPass(unsigned MaxRegionSize) {
+  return new RandomScheduling(MaxRegionSize);
+}
+} // namespace llvm

--- a/llvm/tools/llvm-snippy/lib/Target/AArch64/Target.cpp
+++ b/llvm/tools/llvm-snippy/lib/Target/AArch64/Target.cpp
@@ -736,6 +736,9 @@ public:
     SNIPPY_UNIMPLEMENTED();
   }
 
+  bool mayBeScheduled(const MachineInstr &MI) const override {
+    SNIPPY_UNIMPLEMENTED();
+  }
 
   MachineBasicBlock *generateBranch(InstructionGenerationContext &IGC,
                                     const MCInstrDesc &InstrDesc,

--- a/llvm/tools/llvm-snippy/lib/Target/RISCV/Target.cpp
+++ b/llvm/tools/llvm-snippy/lib/Target/RISCV/Target.cpp
@@ -391,6 +391,15 @@ unsigned getNonZeroReg(const Twine &Desc, const MCRegisterInfo &RI,
       /*Filter*/ [](unsigned Reg) { return Reg == RISCV::X0; }, Mask);
 }
 
+template <bool StrictBarrier = true>
+static void reportSchedulingBarrier(const MachineInstr &MI, raw_ostream &OS) {
+  if constexpr (StrictBarrier)
+    OS << "Unsupported scheduling instruction : ";
+  else
+    OS << "Currently unsupported scheduling instruction : ";
+  MI.print(OS);
+}
+
 static bool isSupportedLoadStore(unsigned Opcode) {
   return isLoadStore(Opcode) || isCLoadStore(Opcode) || isFPLoadStore(Opcode) ||
          isCFPLoadStore(Opcode) || isRVVUnitStrideLoadStore(Opcode) ||
@@ -1897,6 +1906,34 @@ public:
     default:
       return false;
     }
+  }
+
+  bool mayBeScheduled(const MachineInstr &MI) const override {
+    if (MI.isTerminator())
+      return false;
+    if (checkMetadata(MI, SnippyMetadata::Bundle) &&
+        !checkMetadata(MI, SnippyMetadata::Support))
+      return false;
+    if (MI.hasUnmodeledSideEffects() || (MI.getOpcode() == RISCV::AUIPC)) {
+      LLVM_DEBUG(reportSchedulingBarrier(MI, dbgs()));
+      return false;
+    }
+    if (MI.getOpcode() == RISCV::PseudoNOP)
+      return false;
+
+    auto Opcode = MI.getOpcode();
+    if (MI.isCall() || isRVV(Opcode) || snippy::isFloatingPoint(Opcode)) {
+      LLVM_DEBUG(
+          reportSchedulingBarrier</* StrictBarrier */ false>(MI, dbgs()));
+      return false;
+    }
+
+    const auto *MBB = MI.getParent();
+    assert(MBB);
+    if (std::next(MI.getIterator()) == MBB->end())
+      return false;
+
+    return true;
   }
 
   MachineInstr &insertIndirectJump(InstructionGenerationContext &IGC,

--- a/llvm/tools/llvm-snippy/lib/Target/X86/Target.cpp
+++ b/llvm/tools/llvm-snippy/lib/Target/X86/Target.cpp
@@ -396,6 +396,10 @@ public:
     reportUnimplementedError();
   }
 
+  bool mayBeScheduled(const MachineInstr &MI) const override {
+    reportUnimplementedError();
+  }
+
   MachineBasicBlock *generateBranch(InstructionGenerationContext &IGC,
                                     const MCInstrDesc &InstrDesc,
                                     MachineBasicBlock *Dst) const override {


### PR DESCRIPTION
[snippy] implement random scheduling deoptimization
This patch implements deoptimization of the generated snippet by reordering instructions.
It is guaranteed that the final state of the register file and memory remains the same.

The algorithm involves the following steps:
1) A dependency graph of instructions is built based on RAW, WAR, and WAW dependencies.
2) An arbitrary reverse post order (RPO) traversal of this graph is selected.
3) The code is reordered according to the chosen approach.

In practice, multiple different graphs must be constructed to preserve control flow as well as the observed behavior regarding instructions with non-trivial semantics (e.g., fence).