### PR TITLE
[RISCV][fix] take +exact-asm into account on instr size computation

### DIFF
--- a/llvm/lib/Target/RISCV/RISCVInstrInfo.cpp
+++ b/llvm/lib/Target/RISCV/RISCVInstrInfo.cpp
@@ -1836,7 +1836,9 @@ unsigned RISCVInstrInfo::getInstSizeInBytes(const MachineInstr &MI) const {
                               *MF.getTarget().getMCAsmInfo());
   }
 
-  bool CompressionEnabled = !(MI.getAsmPrinterFlags() & RISCV::DoNotCompress);
+  bool CompressionEnabled =
+      !((MI.getAsmPrinterFlags() & RISCV::DoNotCompress) ||
+        STI.hasFeature(RISCV::FeatureExactAssembly));
 
   if (!MI.memoperands_empty()) {
     MachineMemOperand *MMO = *(MI.memoperands_begin());


### PR DESCRIPTION
This caused snippy's code-layout to fail. And potentially affected loops