### PR TITLE
[snippy] Add parsing of negative instructions weights

### DIFF
--- a/llvm/test/tools/llvm-snippy/error-duplicate-instruction-weight.yaml
+++ b/llvm/test/tools/llvm-snippy/error-duplicate-instruction-weight.yaml
@@ -1,0 +1,28 @@
+# RUN: not llvm-snippy %s \
+# RUN:  |& FileCheck %s
+
+sections:
+    - name:      1
+      VMA:       0x10000
+      SIZE:      0x10000
+      LMA:       0x10000
+      ACCESS:    rx
+      PHDR:      'header1'
+    - name:      2
+      VMA:       0x20000
+      SIZE:      0x200
+      LMA:       0x20000
+      ACCESS:    rw
+      PHDR:      'header2'
+
+histogram:
+    - [ADD, 1.0]
+    - [SUB, 3.0]
+    - [SUB, 4.0]
+
+options:
+    mtriple: "riscv64"
+    mcpu: generic-rv64
+    march: "rv64ifc_zifencei"
+
+# CHECK: error: Incorrect histogram: Redeclaration of SUB weight

--- a/llvm/test/tools/llvm-snippy/error-negative-instruction-weight.yaml
+++ b/llvm/test/tools/llvm-snippy/error-negative-instruction-weight.yaml
@@ -1,0 +1,27 @@
+# RUN: not llvm-snippy %s \
+# RUN:  |& FileCheck %s
+
+sections:
+    - name:      1
+      VMA:       0x10000
+      SIZE:      0x10000
+      LMA:       0x10000
+      ACCESS:    rx
+      PHDR:      'header1'
+    - name:      2
+      VMA:       0x20000
+      SIZE:      0x200
+      LMA:       0x20000
+      ACCESS:    rw
+      PHDR:      'header2'
+
+histogram:
+    - [ADD, 1.0]
+    - [SUB, -3.0]
+
+options:
+    mtriple: "riscv64"
+    mcpu: generic-rv64
+    march: "rv64ifc_zifencei"
+
+# CHECK: error: Incorrect histogram: Weight must be a non-negative floating point value, but instruction SUB was given with the weight '-3.0'

--- a/llvm/tools/llvm-snippy/include/snippy/Config/OpcodeHistogram.h
+++ b/llvm/tools/llvm-snippy/include/snippy/Config/OpcodeHistogram.h
@@ -391,6 +391,16 @@ struct OpcodeHistogramNormalization final {
   // Returns non empty error string if something went wrong
   std::string insertHistogramNode(snippy::OpcodeHistogram &Hist, StringRef Name,
                                   double Weight);
+
+private:
+  // Returns true if 'WeightStr' contains a non-negative floating-point value
+  // and isn't NaN or inf. If the return value is true, 'Weight' will be set to
+  // the double representation of 'WeightStr'. Otherwise (if the return value is
+  // false), 'Weight' will remain unchanged.
+  static bool verifyAndSetWeight(StringRef WeightStr, double &Weight) {
+    return not(WeightStr.getAsDouble(Weight, true) or std::isnan(Weight) or
+               std::isinf(Weight) or Weight < 0.0);
+  }
 };
 
 snippy::OpcodeHistogramCodedEntry

--- a/llvm/tools/llvm-snippy/lib/Config/OpcodeHistogram.cpp
+++ b/llvm/tools/llvm-snippy/lib/Config/OpcodeHistogram.cpp
@@ -6,8 +6,10 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include "snippy/Config/OpcodeHistogram.h"
+#include <iostream>
+
 #include "snippy/Config/ConfigIOContext.h"
+#include "snippy/Config/OpcodeHistogram.h"
 
 // FIXME: remove this dependency (an interface should be introduced)
 #include "snippy/Config/PluginWrapper.h"
@@ -90,15 +92,18 @@ OpcodeHistogram OpcodeHistogramNormalization::denormalize(yaml::IO &IO) {
     return Result;
   }
   for (auto &&[NameInfo, WeightStr] : NameWeightSeq) {
-    double Weight = 0.0;
-    if (StringRef(WeightStr).getAsDouble(Weight)) {
-      IO.setError("Incorrect histogram: Weight must be a floating point value");
+    auto Weight = 0.0;
+    auto IsWeightCorrect = verifyAndSetWeight(WeightStr, Weight);
+    if (not IsWeightCorrect) {
+      IO.setError("Incorrect histogram: Weight must be a non-negative floating "
+                  "point value, but instruction " +
+                  NameInfo.Val + " was given with the weight '" + WeightStr +
+                  "'");
       break;
     }
 
-    auto Name = NameInfo.Val;
     if (NameInfo.Kind == yaml::NodeKind::Map) {
-      if (auto ErrStr = insertHistogramNode(Result, Name, Weight);
+      if (auto ErrStr = insertHistogramNode(Result, NameInfo.Val, Weight);
           !ErrStr.empty()) {
         IO.setError(ErrStr);
         return {};
@@ -109,8 +114,18 @@ OpcodeHistogram OpcodeHistogramNormalization::denormalize(yaml::IO &IO) {
         IO.setError(llvm::toString(DecodeEntry.takeError()));
         return {};
       }
-      for (auto &&[Opc, WeightRes] : DecodeEntry->Decoded)
+      for (auto &&[Opc, WeightRes] : DecodeEntry->Decoded) {
+        // FIXME: here we run probability visitor to collect information on
+        // which opcodes were already mentioned
+        Result.reinitProbabilityVisitor();
+        // Check the re-assignment of 'Opc' instruction
+        if (Result.contains(Opc)) {
+          IO.setError("Incorrect histogram: Redeclaration of " + NameInfo.Val +
+                      " weight");
+          return {};
+        }
         Result.insertTopOpcode(Opc, WeightRes);
+      }
     }
   }
   // Recalculate opcode probabilities for the fully constructed histogram

--- a/llvm/tools/llvm-snippy/lib/Config/OpcodeHistogram.cpp
+++ b/llvm/tools/llvm-snippy/lib/Config/OpcodeHistogram.cpp
@@ -6,10 +6,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include <iostream>
-
-#include "snippy/Config/ConfigIOContext.h"
 #include "snippy/Config/OpcodeHistogram.h"
+#include "snippy/Config/ConfigIOContext.h"
 
 // FIXME: remove this dependency (an interface should be introduced)
 #include "snippy/Config/PluginWrapper.h"


### PR DESCRIPTION
Hi!

## Description
This PR addresses the following issue #469

Changes:

A static method `verifyAndSetWeight` was added to `llvm::OpcodeHistogramNormalization` for verification of the weight text representation (including checks for NaN and inf) and translation to double type. This method is used in `OpcodeHistogramNormalization::denormalize`.

## Verification
I've created tests for this situation (negative instruction weights) and successfully ran them along with all other tests on my device.

## Related issue
#469 

:)