### PR TITLE
[snippy] Add check of duplicated instructions in histogram

### DIFF
--- a/llvm/test/tools/llvm-snippy/branches/layout-branches-without-floats.yaml
+++ b/llvm/test/tools/llvm-snippy/branches/layout-branches-without-floats.yaml
@@ -136,7 +136,6 @@ histogram:
   - [C_ADDI, 4.66]
   - [C_ADDIW, 4.66]
   - [C_ADDI_HINT_IMM_ZERO, 4.66]
-  - [C_NOP, 4.66]
   - [C_ADDW, 4.66]
   - [C_ADD_HINT, 4.66]
   - [C_AND, 4.66]

--- a/llvm/test/tools/llvm-snippy/code-layout/compressed.yaml
+++ b/llvm/test/tools/llvm-snippy/code-layout/compressed.yaml
@@ -32,7 +32,6 @@ code-layout:
       last-offset: 0
 histogram:
     - [ADD, 3.0]
-    - [BLT, 1.0]
     - [BEQ, 2.0]
     - [BLT, 2.0]
     - [BGE, 2.0]

--- a/llvm/test/tools/llvm-snippy/duplicated-instructions-error.yaml
+++ b/llvm/test/tools/llvm-snippy/duplicated-instructions-error.yaml
@@ -1,0 +1,31 @@
+# COM: This test checks that an error occurs if the options are incompatible
+
+# RUN: not llvm-snippy %s --model-plugin=None -mtriple=riscv64 -Werror=duplicated-instructions \
+# RUN: |& FileCheck %s
+
+include:
+  - Inputs/sections.yaml
+
+histogram:
+  - [ADD, 1.0] # duplicated ADD
+  - [ADDI, 1.0]
+  - [SUB, 1.0]
+  - [AND, 1.0]
+  - [SRA, 1.0] # duplicated SRA
+  - [SRAI, 1.0]
+  - [ADD, 666] # duplicated ADD
+  - [SRL, 1.0]
+  - [SRLI, 1.0]
+  - [SLL, 1.0]
+  - [SLLI, 1.0] # duplicated SLLI
+  - [SLLI, 777] # duplicated SLLI
+  - [ANDI, 1.0]
+  - [OR, 1.0]
+  - [ORI, 1.0]
+  - [XOR, 1.0]
+  - [XORI, 1.0]
+  - [LW, 1.0]
+  - [SW, 1.0]
+  - [SRA, 67] # duplicated SRA
+
+# CHECK: error: (duplicated-instructions) found duplicate weight definition for: ADD

--- a/llvm/test/tools/llvm-snippy/duplicated-instructions-warning.yaml
+++ b/llvm/test/tools/llvm-snippy/duplicated-instructions-warning.yaml
@@ -1,0 +1,35 @@
+# COM: This test checks that an error occurs if the options are incompatible
+
+# RUN: llvm-snippy %s --model-plugin=None -mtriple=riscv64 \
+# RUN: |& FileCheck %s
+
+include:
+  - Inputs/sections.yaml
+
+histogram:
+  - [ADD, 1.0] # ADD duplicate 1
+  - [ADDI, 1.0]
+  - [SUB, 1.0]
+  - [AND, 1.0]
+  - [SRA, 1.0] # SRA duplicate 1
+  - [SRAI, 1.0]
+  - [ADD, 666] # ADD duplicate 2
+  - [SRL, 1.0]
+  - [SRLI, 1.0]
+  - [SLL, 1.0]
+  - [SLLI, 1.0] # SLLI duplicate 1
+  - [SLLI, 777] # SLLI duplicate 2
+  - [ANDI, 1.0]
+  - [OR, 1.0]
+  - [ORI, 1.0]
+  - [SLLI, 777] # SLLI duplicate 3
+  - [XOR, 1.0]
+  - [XORI, 1.0]
+  - [LW, 1.0]
+  - [SW, 1.0]
+  - [SRA, 67] # SRA duplicate 2
+
+# CHECK-DAG: warning: (duplicated-instructions) found duplicate weight definition for: ADD
+# CHECK-DAG: warning: (duplicated-instructions) found duplicate weight definition for: SLLI
+# CHECK-DAG: warning: (duplicated-instructions) found duplicate weight definition for: SLLI
+# CHECK-DAG: warning: (duplicated-instructions) found duplicate weight definition for: SRA

--- a/llvm/test/tools/llvm-snippy/random-scheduling.yaml
+++ b/llvm/test/tools/llvm-snippy/random-scheduling.yaml
@@ -167,7 +167,6 @@ histogram:
   - [C_LUI_HINT, 4.26]
   - [C_MV, 4.26]
   - [C_MV_HINT, 4.26]
-  - [C_NOP, 4.26]
   - [C_NOP_HINT, 4.26]
   - [C_OR, 4.26]
   - [C_SLLI, 4.26]

--- a/llvm/test/tools/llvm-snippy/reserved-regs/FP-reserved-aliases-3.yaml
+++ b/llvm/test/tools/llvm-snippy/reserved-regs/FP-reserved-aliases-3.yaml
@@ -30,7 +30,6 @@ histogram:
     - [FMSUB_S, 1.0]
     - [FNMSUB_S, 1.0]
     - [FNMADD_S, 1.0]
-    - [FADD_S, 1.0]
     - [FSUB_S, 1.0]
     - [FMUL_S, 1.0]
     - [FDIV_S, 1.0]

--- a/llvm/test/tools/llvm-snippy/reserved-regs/FP-reserved-aliases-4.yaml
+++ b/llvm/test/tools/llvm-snippy/reserved-regs/FP-reserved-aliases-4.yaml
@@ -30,7 +30,6 @@ histogram:
     - [FMSUB_S, 1.0]
     - [FNMSUB_S, 1.0]
     - [FNMADD_S, 1.0]
-    - [FADD_S, 1.0]
     - [FSUB_S, 1.0]
     - [FMUL_S, 1.0]
     - [FDIV_S, 1.0]

--- a/llvm/tools/llvm-snippy/include/snippy/Config/OpcodeHistogram.h
+++ b/llvm/tools/llvm-snippy/include/snippy/Config/OpcodeHistogram.h
@@ -11,15 +11,20 @@
 
 #include "snippy/Config/HistogramPatterns.h"
 #include "snippy/Config/OpcodeHistogramVisitor.h"
+#include "snippy/Support/DiagnosticInfo.h"
 #include "snippy/Support/OpcodeCache.h"
 #include "snippy/Support/YAMLHistogram.h"
 #include "snippy/Support/YAMLUtils.h"
 
+#include "llvm/ADT/STLExtras.h"
+#include "llvm/IR/Instruction.h"
+#include "llvm/IR/LLVMContext.h"
 #include "llvm/MC/MCInstrDesc.h"
 #include "llvm/Support/Error.h"
 
 #include <algorithm>
 #include <cmath>
+#include <cstddef>
 #include <iterator>
 #include <map>
 #include <numeric>
@@ -414,6 +419,24 @@ private:
           formatv("'{}' should be a positive double value", WeightStr));
     }
     return Weight;
+  }
+
+  static void duplicateInstructionMsg(LLVMContext &LLVMCtx,
+                                      StringRef NameOfDuplicatedInstruction) {
+    // 'snippy::warn' and 'snippy::notice' are separated to split the message
+    // about the reason for the warning and the message about potential future
+    // changes in this warning case.
+    snippy::warn(snippy::WarningName::DuplicatedInstructions, LLVMCtx,
+                 "found duplicate weight definition for",
+                 NameOfDuplicatedInstruction);
+    // FIXME: remove notice when duplicated instructions become an error by
+    // default
+    snippy::notice(snippy::WarningName::DuplicatedInstructions, LLVMCtx,
+                   "Duplicate weight definitions will be forbidden in the next "
+                   "major release. "
+                   "It is recommended to fix this. For now",
+                   "the last weight in the histogram will be used and all "
+                   "others will be ignored");
   }
 };
 

--- a/llvm/tools/llvm-snippy/include/snippy/Support/DiagnosticInfo.h
+++ b/llvm/tools/llvm-snippy/include/snippy/Support/DiagnosticInfo.h
@@ -51,7 +51,8 @@ namespace snippy {
   WARN_CASE(OperandsReinitialization, "operands-reinitialization")             \
   WARN_CASE(LoopCountersOnStack, "loop-counters-on-stack")                     \
   WARN_CASE(SMCWithoutEffect, "smc-without-effect")                            \
-  WARN_CASE(DeprecatedOption, "deprecated-option")
+  WARN_CASE(DeprecatedOption, "deprecated-option")                             \
+  WARN_CASE(DuplicatedInstructions, "duplicated-instructions")
 
 #ifdef WARN_CASE
 #error WARN_CASE should not be defined at this point

--- a/llvm/tools/llvm-snippy/lib/Config/OpcodeHistogram.cpp
+++ b/llvm/tools/llvm-snippy/lib/Config/OpcodeHistogram.cpp
@@ -17,6 +17,7 @@
 #include "llvm/Support/YAMLTraits.h"
 #include "llvm/Support/raw_ostream.h"
 
+#include "snippy/Support/OpcodeCache.h"
 #include "snippy/Target/Target.h"
 
 #include <optional>
@@ -93,6 +94,7 @@ OpcodeHistogram OpcodeHistogramNormalization::denormalize(yaml::IO &IO) {
     Result.reinitProbabilityVisitor();
     return Result;
   }
+  auto OpCC = ConfigIOCtx->OpCC;
   for (auto &&[NameInfo, WeightStr] : NameWeightSeq) {
     auto Weight = parseWeight(WeightStr);
     if (!Weight) {
@@ -102,6 +104,13 @@ OpcodeHistogram OpcodeHistogramNormalization::denormalize(yaml::IO &IO) {
     }
 
     auto Name = NameInfo.Val;
+    if (auto OpcOpt = OpCC.code(Name); OpcOpt) {
+      auto Opc = Tgt.getInternalOpcode(*OpcOpt);
+      bool OpcAlreadyDefined = Result.topOpcodes().count(Opc);
+      if (OpcAlreadyDefined) {
+        duplicateInstructionMsg(ConfigIOCtx->State.getCtx(), Name);
+      }
+    }
     if (NameInfo.Kind == yaml::NodeKind::Map) {
       if (auto ErrStr = insertHistogramNode(Result, Name, Weight.get());
           !ErrStr.empty()) {
@@ -109,7 +118,7 @@ OpcodeHistogram OpcodeHistogramNormalization::denormalize(yaml::IO &IO) {
         return {};
       }
     } else if (NameInfo.Kind == yaml::NodeKind::Scalar) {
-      auto DecodeEntry = decodeInstrRegex(IO, NameInfo.Val, Weight.get());
+      auto DecodeEntry = decodeInstrRegex(IO, Name, Weight.get());
       if (!DecodeEntry) {
         IO.setError(llvm::toString(DecodeEntry.takeError()));
         return {};


### PR DESCRIPTION
## Hi!

This PR address the following issue - #470 

## Changes
In each iteration of the
```cpp
for (auto &&[Opc, WeightRes] : DecodeEntry->Decoded)
```
we check if Result already contains Opc:
```cpp
// OpcodeHistogramNormalization::denormalize
      for (auto &&[Opc, WeightRes] : DecodeEntry->Decoded) {
        // FIXME: here we run probability visitor to collect information on
        // which opcodes were already mentioned
        Result.reinitProbabilityVisitor();
        // Check the re-assignment of 'Opc' instruction
        if (Result.contains(Opc)) { // not a problem, because SmallVector
          IO.setError("Incorrect histogram: Redeclaration of " + NameInfo.Val +
                      " weight");
          return {};
        }
        Result.insertTopOpcode(Opc, WeightRes);
      }
```
`Result` is a SmallVector, so `O(n)` complexity (method `contains`) per iteration isn't a problem. Anyway, this can be just first simple solution.

## Verification
A test with a histogram containing a duplicated instruction was also added. This test and all other tests completed successfully on my device.


:)