### PR TITLE
[snippy] Add check of negative instructions weights in histogram

### DIFF
--- a/llvm/test/tools/llvm-snippy/histogram-weight-not-double.yaml
+++ b/llvm/test/tools/llvm-snippy/histogram-weight-not-double.yaml
@@ -33,4 +33,4 @@ histogram:
     - [LW, 10.0]
     - [SW, 10.0]
 
-# CHECK: error: Incorrect histogram: Weight must be a floating point value
+# CHECK: error: MUL is given with incorrect weight: '1.0_o' can't be converted to double

--- a/llvm/test/tools/llvm-snippy/incorrect-weight-error.yaml
+++ b/llvm/test/tools/llvm-snippy/incorrect-weight-error.yaml
@@ -1,0 +1,45 @@
+# COM: This test checks that an error occurs if the options are incompatible
+
+# RUN: sed -e s/INCORRECT_WEIGHT_VALUE/-1.0/ %s > %t.1.yaml
+# RUN: not llvm-snippy %t.1.yaml --model-plugin=None -mtriple=riscv64 \
+# RUN: |& FileCheck %t.1.yaml
+
+# RUN: sed -e s/INCORRECT_WEIGHT_VALUE/-7.215/ %s > %t.2.yaml
+# RUN: not llvm-snippy %t.2.yaml --model-plugin=None -mtriple=riscv64 \
+# RUN: |& FileCheck %t.2.yaml
+
+# RUN: sed -e s/INCORRECT_WEIGHT_VALUE/NaN/ %s > %t.3.yaml
+# RUN: not llvm-snippy %t.3.yaml --model-plugin=None -mtriple=riscv64 \
+# RUN: |& FileCheck %t.3.yaml
+
+# RUN: sed -e s/INCORRECT_WEIGHT_VALUE/-NaN/ %s > %t.4.yaml
+# RUN: not llvm-snippy %t.4.yaml --model-plugin=None -mtriple=riscv64 \
+# RUN: |& FileCheck %t.4.yaml
+
+# RUN: sed -e s/INCORRECT_WEIGHT_VALUE/inf/ %s > %t.5.yaml
+# RUN: not llvm-snippy %t.5.yaml --model-plugin=None -mtriple=riscv64 \
+# RUN: |& FileCheck %t.5.yaml
+
+# RUN: sed -e s/INCORRECT_WEIGHT_VALUE/-inf/ %s > %t.6.yaml
+# RUN: not llvm-snippy %t.6.yaml --model-plugin=None -mtriple=riscv64 \
+# RUN: |& FileCheck %t.6.yaml
+
+sections:
+  - name:      1
+    VMA:       0x210000
+    SIZE:      0x100000
+    LMA:       0x210000
+    ACCESS:    rx
+  - name:      2
+    VMA:       0x400000
+    SIZE:      0x100000
+    LMA:       0x400000
+    ACCESS:    rw
+
+histogram:
+    - [ADD, 1.0]
+    - [ADDI, INCORRECT_WEIGHT_VALUE]
+    - [SUB, 1.0]
+    - [BEQ, 1.0]
+
+# CHECK: error: ADDI is given with incorrect weight: 'INCORRECT_WEIGHT_VALUE' should be a positive double value

--- a/llvm/tools/llvm-snippy/include/snippy/Config/OpcodeHistogram.h
+++ b/llvm/tools/llvm-snippy/include/snippy/Config/OpcodeHistogram.h
@@ -15,6 +15,7 @@
 #include "snippy/Support/YAMLUtils.h"
 
 #include "llvm/MC/MCInstrDesc.h"
+#include "llvm/Support/Error.h"
 
 #include <algorithm>
 #include <cmath>
@@ -391,6 +392,25 @@ struct OpcodeHistogramNormalization final {
   // Returns non empty error string if something went wrong
   std::string insertHistogramNode(snippy::OpcodeHistogram &Hist, StringRef Name,
                                   double Weight);
+
+private:
+  static Expected<double> parseWeight(StringRef WeightStr) {
+    auto Weight = 0.0;
+    auto ParseFailure = WeightStr.getAsDouble(Weight, true);
+    if (ParseFailure) {
+      return makeFailure(
+          snippy::Errc::InvalidArgument,
+          formatv("'{}' can't be converted to double", WeightStr));
+    }
+    auto IncorrectWeightValue =
+        (std::isnan(Weight) || std::isinf(Weight) || Weight < 0.0);
+    if (IncorrectWeightValue) {
+      return makeFailure(
+          snippy::Errc::InvalidArgument,
+          formatv("'{}' should be a positive double value", WeightStr));
+    }
+    return Weight;
+  }
 };
 
 snippy::OpcodeHistogramCodedEntry

--- a/llvm/tools/llvm-snippy/lib/Config/OpcodeHistogram.cpp
+++ b/llvm/tools/llvm-snippy/lib/Config/OpcodeHistogram.cpp
@@ -90,21 +90,22 @@ OpcodeHistogram OpcodeHistogramNormalization::denormalize(yaml::IO &IO) {
     return Result;
   }
   for (auto &&[NameInfo, WeightStr] : NameWeightSeq) {
-    double Weight = 0.0;
-    if (StringRef(WeightStr).getAsDouble(Weight)) {
-      IO.setError("Incorrect histogram: Weight must be a floating point value");
+    auto Weight = parseWeight(WeightStr);
+    if (!Weight) {
+      IO.setError(NameInfo.Val + " is given with incorrect weight: " +
+                  llvm::toString(Weight.takeError()));
       break;
     }
 
     auto Name = NameInfo.Val;
     if (NameInfo.Kind == yaml::NodeKind::Map) {
-      if (auto ErrStr = insertHistogramNode(Result, Name, Weight);
+      if (auto ErrStr = insertHistogramNode(Result, Name, Weight.get());
           !ErrStr.empty()) {
         IO.setError(ErrStr);
         return {};
       }
     } else if (NameInfo.Kind == yaml::NodeKind::Scalar) {
-      auto DecodeEntry = decodeInstrRegex(IO, NameInfo.Val, Weight);
+      auto DecodeEntry = decodeInstrRegex(IO, NameInfo.Val, Weight.get());
       if (!DecodeEntry) {
         IO.setError(llvm::toString(DecodeEntry.takeError()));
         return {};


### PR DESCRIPTION
## Hi!

This PR addresses the following issue #469

## Changes

A static method `verifyAndSetWeight` was added to `llvm::OpcodeHistogramNormalization` for verification of the weight text representation (including checks for NaN and inf) and translation to double type. This method is used in `OpcodeHistogramNormalization::denormalize`.

## Verification
I've created tests for this situation (negative instruction weight) and successfully ran them along with all other tests on my device.

## Related issue
#469 

:)