### PR TITLE
[snippy] Fix bad histogram error message

### DIFF
--- a/llvm/tools/llvm-snippy/llvm-snippy.cpp
+++ b/llvm/tools/llvm-snippy/llvm-snippy.cpp
@@ -142,7 +142,7 @@ static Config readSnippyConfig(LLVMState &State, RegPoolWrapper &RP,
       Config::create(IPP, RP, State, ProgCfg, OpCC, ParseWithPlugin);
   if (auto Err = ConfigOrErr.takeError())
     snippy::fatal(
-        Ctx, "Failed to parse file \"" + Twine(IPP.getPrimaryFilename()) + "\'",
+        Ctx, "Failed to parse file \"" + Twine(IPP.getPrimaryFilename()) + "\"",
         toString(std::move(Err)));
   return std::move(*ConfigOrErr);
 }


### PR DESCRIPTION
## Hi!

I've fixed this issue #475 

## Description

Only one change in `llvm/tools/llvm-snippy/llvm-snippy.cpp:145`:
```cpp
Ctx, "Failed to parse file \"" + Twine(IPP.getPrimaryFilename()) + "\"" /* here was \' */,
```