### PR TITLE
[snippy] Support `riscv-disallow-intersecting-mem-accesses` for RVV indexed ops

### DIFF
--- a/llvm/test/tools/llvm-snippy/memory-scheme/vector-nonintersecting-indexed-large-stride-small-index-fail.yaml
+++ b/llvm/test/tools/llvm-snippy/memory-scheme/vector-nonintersecting-indexed-large-stride-small-index-fail.yaml
@@ -1,0 +1,57 @@
+# RUN: llvm-snippy %s -model-plugin None
+# RUN: not llvm-snippy %s -riscv-disallow-intersecting-mem-accesses="VSUXEI8_V" -model-plugin None |& FileCheck %s
+#
+options:
+  mtriple: riscv64
+  mattr: +v
+  num-instrs: 10
+sections:
+  - name: 1
+    VMA: 0x80000000
+    SIZE: 0x00400000
+    LMA: 0x80000000
+    ACCESS: rx
+  - name: 2
+    VMA: 0x80600000
+    SIZE: 0x00400000
+    LMA: 0x80600000
+    ACCESS: r
+  - name: 3
+    VMA: 0x81000000
+    SIZE: 0x00400000
+    LMA: 0x81000000
+    ACCESS: rw
+access-ranges:
+  - start: 0x81000000
+    size: 0x1000
+    stride: 64 # Large minimum stride such that 8 bit indices aren't enough
+    first-offset: 0
+    last-offset: 0
+riscv-vector-unit:
+  mode-change-bias:
+    P: 0.2
+  mode-distribution:
+    VM:
+      - [all_ones, 1.0]
+    VL:
+      - [8, 1.0]
+    VXRM:
+      rnu: 1.0
+      rne: 1.0
+      rdn: 1.0
+      ron: 1.0
+    VTYPE:
+      SEW:
+        sew_8: 1.0
+      LMUL:
+        m1: 1.0
+      VMA:
+        mu: 1.0
+        ma: 1.0
+      VTA:
+        tu: 1.0
+        ta: 1.0
+histogram:
+  - ["VSUXEI8_V", 1.0]
+
+# CHECK: error: Can't fulfill non-intersecting RVV index requirements: Instruction needs to access 448 consecutive bytes, but maximum represenatable index is 255

--- a/llvm/test/tools/llvm-snippy/memory-scheme/vector-nonintersecting-indexed-only-fail.yaml
+++ b/llvm/test/tools/llvm-snippy/memory-scheme/vector-nonintersecting-indexed-only-fail.yaml
@@ -1,0 +1,63 @@
+# COM: Check that using riscv-disallow-intersecting-mem-accesses requests number of elements > 1.
+# COM: This is done by specifying a VL larger than the scheme can accommodate. Without the option
+# COM: the generated indices are duplicated.
+#
+# RUN: llvm-snippy %s -model-plugin None
+# RUN: not llvm-snippy %s -riscv-disallow-intersecting-mem-accesses="VLUXEI8_V" -model-plugin None |& FileCheck %s
+#
+# CHECK: Memory schemes are to restrictive to generate access (size: 1, alignment: 1, stride: 1, number of elements: 4)
+options:
+  mtriple: riscv64
+  mattr: +v
+  num-instrs: 10000
+  init-regs-in-elf: true
+  verify-mi: true
+  riscv-disable-misaligned-access: all
+sections:
+  - name: 1
+    VMA: 0x80000000
+    SIZE: 0x00400000
+    LMA: 0x80000000
+    ACCESS: rx
+  - name: 2
+    VMA: 0x80600000
+    SIZE: 0x00400000
+    LMA: 0x80600000
+    ACCESS: r
+  - name: 3
+    VMA: 0x81000000
+    SIZE: 0x00400000
+    LMA: 0x81000000
+    ACCESS: rw
+access-ranges:
+  - start: 0x81000000
+    size: 0x3
+    stride: 1
+    first-offset: 0
+    last-offset: 0
+riscv-vector-unit:
+  mode-change-bias:
+    P: 0.2
+  mode-distribution:
+    VM:
+      - [all_ones, 1.0]
+    VL:
+      - [4, 1.0]
+    VXRM:
+      rnu: 1.0
+      rne: 1.0
+      rdn: 1.0
+      ron: 1.0
+    VTYPE:
+      SEW:
+        sew_8: 1.0
+      LMUL:
+        m1: 1.0
+      VMA:
+        mu: 1.0
+        ma: 1.0
+      VTA:
+        tu: 1.0
+        ta: 1.0
+histogram:
+  - ["VLUXEI8_V", 1.0]

--- a/llvm/test/tools/llvm-snippy/memory-scheme/vector-nonintersecting-indexed-segmented-only-fail.yaml
+++ b/llvm/test/tools/llvm-snippy/memory-scheme/vector-nonintersecting-indexed-segmented-only-fail.yaml
@@ -1,0 +1,63 @@
+# COM: Check that using riscv-disallow-intersecting-mem-accesses requests number of elements > 1.
+# COM: This is done by specifying a VL larger than the scheme can accommodate. Without the option
+# COM: the generated indices are duplicated.
+#
+# RUN: llvm-snippy %s -model-plugin None
+# RUN: not llvm-snippy %s -riscv-disallow-intersecting-mem-accesses="VLUXSEG7EI32_V" -model-plugin None |& FileCheck %s
+#
+# CHECK: Memory schemes are to restrictive to generate access (size: 14, alignment: 2, stride: 14, number of elements: 8)
+options:
+  mtriple: riscv64
+  mattr: +v
+  num-instrs: 10000
+  init-regs-in-elf: true
+  verify-mi: true
+  riscv-disable-misaligned-access: all
+sections:
+  - name: 1
+    VMA: 0x80000000
+    SIZE: 0x00400000
+    LMA: 0x80000000
+    ACCESS: rx
+  - name: 2
+    VMA: 0x80600000
+    SIZE: 0x00400000
+    LMA: 0x80600000
+    ACCESS: r
+  - name: 3
+    VMA: 0x8100
+    SIZE: 0x1000
+    LMA: 0x8100
+    ACCESS: rw
+access-ranges:
+  - start: 0x8100
+    size: 111
+    stride: 1
+    first-offset: 0
+    last-offset: 0
+riscv-vector-unit:
+  mode-change-bias:
+    P: 0.2
+  mode-distribution:
+    VM:
+      - [all_ones, 1.0]
+    VL:
+      - [8, 1.0]
+    VXRM:
+      rnu: 1.0
+      rne: 1.0
+      rdn: 1.0
+      ron: 1.0
+    VTYPE:
+      SEW:
+        sew_16: 1.0
+      LMUL:
+        m1: 1.0
+      VMA:
+        mu: 1.0
+        ma: 1.0
+      VTA:
+        tu: 1.0
+        ta: 1.0
+histogram:
+  - ["VLUXSEG7EI32_V", 1.0]

--- a/llvm/test/tools/llvm-snippy/memory-scheme/vector-nonintersecting-indexed.yaml
+++ b/llvm/test/tools/llvm-snippy/memory-scheme/vector-nonintersecting-indexed.yaml
@@ -1,0 +1,58 @@
+# REQUIRES: asserts
+# REQUIRES: riscv-rvv
+# RUN: llvm-snippy %s -debug-only=snippy-riscv -model-plugin None |& grep -oP "IndexValue.*: \K.*" | sort | uniq | wc -l | FileCheck %s
+# COM: Check that 8 unique indices are generated
+# CHECK: 8
+options:
+  mtriple: riscv64
+  mattr: +v
+  num-instrs: 1
+  riscv-disallow-intersecting-mem-accesses: ".*"
+sections:
+  - name: 1
+    VMA: 0x80000000
+    SIZE: 0x00400000
+    LMA: 0x80000000
+    ACCESS: rx
+  - name: 2
+    VMA: 0x80600000
+    SIZE: 0x00400000
+    LMA: 0x80600000
+    ACCESS: r
+  - name: 3
+    VMA: 0x81000000
+    SIZE: 0x00400000
+    LMA: 0x81000000
+    ACCESS: rw
+access-ranges:
+  - start: 0x81000000
+    size: 0x8
+    stride: 1
+    first-offset: 0
+    last-offset: 0
+riscv-vector-unit:
+  mode-change-bias:
+    P: 0.2
+  mode-distribution:
+    VM:
+      - [all_ones, 1.0]
+    VL:
+      - [8, 1.0]
+    VXRM:
+      rnu: 1.0
+      rne: 1.0
+      rdn: 1.0
+      ron: 1.0
+    VTYPE:
+      SEW:
+        sew_8: 1.0
+      LMUL:
+        m1: 1.0
+      VMA:
+        mu: 1.0
+        ma: 1.0
+      VTA:
+        tu: 1.0
+        ta: 1.0
+histogram:
+  - ["VLUXEI8_V", 1.0]

--- a/llvm/tools/llvm-snippy/lib/Config/MemoryScheme.cpp
+++ b/llvm/tools/llvm-snippy/lib/Config/MemoryScheme.cpp
@@ -711,11 +711,11 @@ AddressInfo MemoryAccessRange::randomAddress(const AddressGenInfo &Params) {
   }
   assert(Offset <= MaxOffset);
 
-  auto MinOffAligned = alignDown(Offset, LCStride);
+  auto MinOffAligned = alignDown(Offset, RequiredStride);
 
   AddressInfo AI;
   AI.Address = Start + Offset;
-  AI.MaxOffset = alignDown(Size - Offset - AccessSize, LCStride);
+  AI.MaxOffset = alignDown(Size - Offset - AccessSize, RequiredStride);
   AI.MinOffset = -static_cast<int long long>(MinOffAligned);
   AI.MinStride = RequiredStride;
   AI.AccessSize = AccessSize;

--- a/llvm/tools/llvm-snippy/lib/Target/RISCV/RISCVGenerated.h
+++ b/llvm/tools/llvm-snippy/lib/Target/RISCV/RISCVGenerated.h
@@ -743,6 +743,16 @@ inline bool isRVVIndexedSegLoadStore(unsigned Opcode) {
   }
 }
 
+inline bool isRVVIndexedUnorderedSegLoadStore(unsigned Opcode) {
+  switch (Opcode) {
+  default:
+    return false;
+  case RVV_INDEX_SEG_EACHNFIELDS_PLACER(VLUXSEG):
+  case RVV_INDEX_SEG_EACHNFIELDS_PLACER(VSUXSEG):
+    return true;
+  }
+}
+
 inline bool isRVVStridedStore(unsigned Opcode) {
   switch (Opcode) {
   default:
@@ -767,7 +777,6 @@ inline bool isRVVStridedSegStore(unsigned Opcode) {
 #undef RVV_SEG_EACHNFIELDS_PLACER
 #undef RVV_INDEX_SEG_EACHNFIELDS_PLACER
 #undef RVV_SEG_EACHEEW_PLACER
-#undef RVV_SEG_EACHEIEW_PLACER
 
 inline bool isRVVWholeRegLoadStore(unsigned Opcode) {
   switch (Opcode) {
@@ -1115,25 +1124,25 @@ inline bool isRVVIndexedLoadStore(unsigned Opcode) {
   switch (Opcode) {
   default:
     return false;
-  case RISCV::VLUXEI8_V:
-  case RISCV::VLUXEI16_V:
-  case RISCV::VLUXEI32_V:
-  case RISCV::VLUXEI64_V:
-  case RISCV::VLOXEI8_V:
-  case RISCV::VLOXEI16_V:
-  case RISCV::VLOXEI32_V:
-  case RISCV::VLOXEI64_V:
-  case RISCV::VSUXEI8_V:
-  case RISCV::VSUXEI16_V:
-  case RISCV::VSUXEI32_V:
-  case RISCV::VSUXEI64_V:
-  case RISCV::VSOXEI8_V:
-  case RISCV::VSOXEI16_V:
-  case RISCV::VSOXEI32_V:
-  case RISCV::VSOXEI64_V:
+  case RVV_SEG_EACHEIEW_PLACER(VLUX, ):
+  case RVV_SEG_EACHEIEW_PLACER(VLOX, ):
+  case RVV_SEG_EACHEIEW_PLACER(VSUX, ):
+  case RVV_SEG_EACHEIEW_PLACER(VSOX, ):
     return true;
   }
 }
+
+inline bool isRVVIndexedUnorderedLoadStore(unsigned Opcode) {
+  switch (Opcode) {
+  default:
+    return false;
+  case RVV_SEG_EACHEIEW_PLACER(VLUX, ):
+  case RVV_SEG_EACHEIEW_PLACER(VSUX, ):
+    return true;
+  }
+}
+
+#undef RVV_SEG_EACHEIEW_PLACER
 
 inline bool isRVVUnitStrideMaskLoadStore(unsigned Opcode) {
   switch (Opcode) {

--- a/llvm/tools/llvm-snippy/lib/Target/RISCV/Target.cpp
+++ b/llvm/tools/llvm-snippy/lib/Target/RISCV/Target.cpp
@@ -813,25 +813,56 @@ static APInt getMaxPossibleIndexValue(const MCInstrDesc &InstrDesc,
                                   XLen);
 }
 
-static APInt
-getBaseAddressForRVVIndexed(size_t XLen, APInt FirstLegalAddr,
-                            APInt LastLegalAddr, const MCInstrDesc &InstrDesc,
-                            std::optional<MemAddr> Preselected = {}) {
+/// Randomly select an address used for indexed RVV ops. See the detailed
+/// comment in breakDownAddrForRVVIndexed for the reasoning. IndexShiftHeadroom
+/// is the number of consecutive bytes reachable from the selected base address
+/// via indices in range [0, maxPossibleIndexValue].
+static APInt getBaseAddressForRVVIndexed(size_t XLen, APInt FirstLegalAddr,
+                                         APInt LastLegalAddr,
+                                         const MCInstrDesc &InstrDesc,
+                                         std::optional<MemAddr> Preselected,
+                                         APInt IndexShiftHeadroom) {
   if (Preselected)
     return APInt(XLen, *Preselected);
-  auto IndexMaxValue = RandEngine::genInRangeInclusive(
-      getMaxPossibleIndexValue(InstrDesc, XLen));
-  // Pick the legal random Base' value with the index constraints for current
-  // instruction. So, from the equation:
-  // FirstLegalAddr <= Base' + IndexMaxValue <= LastLegalAddr
-  // FirstLegalAddr - IndexMaxValue  <= Base' <= LastLegalAddr - IndexMaxValue
+
+  // This can happen if the selected scheme has a large stride specified and the
+  // instruction uses a small index register. TODO: Do something better then
+  // erroring out. Hard problem to solve and unclear whether it's worth solving.
+  // TODO: Return Expected and include the machine instr in the error message.
+  auto MaxPossibleIndexValue = getMaxPossibleIndexValue(InstrDesc, XLen);
+  if (IndexShiftHeadroom.ugt(MaxPossibleIndexValue)) {
+    snippy::fatal("Can't fulfill non-intersecting RVV index requirements",
+                  Twine("Instruction needs to access ")
+                      .concat(Twine(IndexShiftHeadroom.getZExtValue()))
+                      .concat(" consecutive bytes, but maximum "
+                              "represenatable index is ")
+                      .concat(Twine(MaxPossibleIndexValue.getZExtValue())));
+  }
+
   assert(FirstLegalAddr.getBitWidth() == XLen);
   assert(LastLegalAddr.getBitWidth() == XLen);
 
+  auto IndexShiftMaxValue = RandEngine::genInRangeInclusive(
+      getMaxPossibleIndexValue(InstrDesc, XLen) - IndexShiftHeadroom);
+
+  LLVM_DEBUG(dbgs().indent(2)
+             << "IndexShiftMaxValue: 0x"
+             << utohexstr(IndexShiftMaxValue.getZExtValue()) << "\n");
+
+  // Pick the legal random Base' value with the index constraints for current
+  // instruction. When IndexShiftHeadroom is nonzero, we also ensure that the
+  // base address is selected in such a way, that the resulting legal index
+  // range can be used to access IndexShiftHeadroom consecutive bytes. Note that
+  // IndexShiftMaxValue reduces the maximum offset that can be applied to the
+  // start of the range (FirstLegalAddr), but LastLegalAddr is affected in a
+  // different manner - it has to be reduced, not increased like it happens with
+  // MinBase.
+
   // NOTE: All arithmetic is modulo XLen and it's expected that these operations
   // will overflow. Either both at the same time or just one.
-  auto MinBase = FirstLegalAddr - IndexMaxValue;
-  auto MaxBase = LastLegalAddr - IndexMaxValue;
+  auto MinBase = FirstLegalAddr - IndexShiftMaxValue;
+  auto MaxBase =
+      MinBase + ((LastLegalAddr - IndexShiftHeadroom) - FirstLegalAddr);
 
   LLVM_DEBUG(dbgs().indent(2)
              << "MinBase: 0x" << utohexstr(MinBase.getZExtValue()) << "\n");
@@ -960,7 +991,13 @@ static std::pair<AddressParts, MemAddresses> breakDownAddrForRVVIndexed(
          (LastLegalAddr.getZExtValue() % AddrInfo.MinStride));
 
   auto BaseAddr = getBaseAddressForRVVIndexed(
-      ST.getXLen(), FirstLegalAddr, LastLegalAddr, InstrDesc, MainPartAddr);
+      ST.getXLen(), FirstLegalAddr, LastLegalAddr, InstrDesc, MainPartAddr,
+      // NOTE: It's not clear how to handle cases when the index range is too
+      // small to reach into VL unique elements when the scheme has a large
+      // stride.
+      /*IndexShiftHeadroom=*/TgtCtx.disallowIntersectingMemoryAccesses(Opcode)
+          ? APInt(XLen, AddrInfo.MinStride * (VL - 1))
+          : APInt::getZero(XLen));
 
   LLVM_DEBUG(dbgs().indent(2)
              << Twine("Generated BaseAddress 0x")
@@ -1015,6 +1052,12 @@ static std::pair<AddressParts, MemAddresses> breakDownAddrForRVVIndexed(
   assert(IndexMaxValue.uge(IndexMinValue));
   auto MaxN = (IndexMaxValue - IndexMinValue).udiv(AddrInfo.MinStride);
 
+  std::vector<uint64_t> StridesTakenForElements = unwrapOrFatal(
+      TgtCtx.disallowIntersectingMemoryAccesses(Opcode)
+          ? RandEngine::genNUniqInInterval<uint64_t>(0, MaxN.getZExtValue(), VL)
+          : RandEngine::genNInRangeInclusive<uint64_t>(0, MaxN.getZExtValue(),
+                                                       VL));
+
   AddressPart MainPart{AddrReg.getReg(), BaseAddr};
 
   AddressParts ValueToReg = {MainPart};
@@ -1030,10 +1073,8 @@ static std::pair<AddressParts, MemAddresses> breakDownAddrForRVVIndexed(
     auto NElts = std::min(VL, NIdxsPerVReg);
     auto Offsets = APInt::getZero(VLEN);
     for (size_t ElemIdx = 0; ElemIdx < NElts; ++ElemIdx) {
-      // TODO: for unordered stores, generating indices like this is not
-      // correct, since store order for overlapping regions is not defined
-      // FIXME: What about alignment?
-      auto N = RandEngine::genInRangeInclusive(MaxN);
+      auto N = StridesTakenForElements.back();
+      StridesTakenForElements.pop_back();
       auto IndexValue = IndexMinValue + AddrInfo.MinStride * N;
 
       assert(IndexValue.ule(IndexMaxValue));
@@ -5759,8 +5800,9 @@ matchRVVOpcodesWithDisallowedIntersectingAccesses(const OpcodeHistogram &OpHist,
   DenseSet<unsigned> MatchedOpcodes;
   for (auto Opcode : make_filter_range(
            make_first_range(OpHist.topOpcodes()), [](unsigned Opc) {
-             // TODO: Support indexed unordered stores too.
-             return isRVVStridedStore(Opc) || isRVVStridedSegStore(Opc);
+             return isRVVStridedStore(Opc) || isRVVStridedSegStore(Opc) ||
+                    isRVVIndexedUnorderedLoadStore(Opc) ||
+                    isRVVIndexedUnorderedSegLoadStore(Opc);
            })) {
     if (OpcRegex.match(MCII.getName(Opcode)))
       MatchedOpcodes.insert(Opcode);


### PR DESCRIPTION
[snippy] Support `riscv-disallow-intersecting-mem-accesses` for RVV indexed ops